### PR TITLE
Ensure dispose is called in GLEventListener when using an Animator

### DIFF
--- a/src/newt/classes/com/jogamp/newt/opengl/GLWindow.java
+++ b/src/newt/classes/com/jogamp/newt/opengl/GLWindow.java
@@ -85,10 +85,29 @@ public class GLWindow implements GLAutoDrawable, Window, NEWTEventConsumer {
                 }
 
                 public void windowDestroyNotify(WindowEvent e) {
-                    if( !GLWindow.this.window.isSurfaceLockedByOtherThread() && !GLWindow.this.helper.isExternalAnimatorAnimating() ) {
+                    // Is an animator thread perform rendering?
+                    if (GLWindow.this.helper.isExternalAnimatorAnimating()) {
+                        // Pause animations before initiating destroy.
+                        GLAnimatorControl ctrl = GLWindow.this.helper
+                                .getAnimator();
+                        ctrl.pause();
+
                         destroy();
-                    } else {
+
+                        // Resume animations.
+                        ctrl.resume();
+                    }
+                    // Is the surface locked another thread?
+                    else if (GLWindow.this.window
+                            .isSurfaceLockedByOtherThread()) {
+                        // Flag that destroy should be performed on the next
+                        // attempt to display.
                         sendDestroy = true;
+                    }
+                    else {
+                        // Without an external thread animating or locking the
+                        // surface, we should be safe.
+                        destroy ();
                     }
                 }
             });


### PR DESCRIPTION
The target was to have a very simple application work consistently, including ensuring that dispose(GLAutodrawable) was called during the shutdown.  The setup was a GLWindow with a GLEventListener for rendering, and Animator to drive the animation, and a WindowListener to stop the animation when the window was closed.

The original destroy handling resulted in the sendDestroy flag being set (for the next call to display in GLWindow), but the windowDestroyNotify(WindowEvent) had already been made.  This made it difficult to shutdown the animator thread automatically because at least one final call to display() needed to be made to ensure that the shutdown continued.  With the addition of the GLAnimatorControl, we are now able to pause animation to complete the destruction process in one step.
