### PR TITLE
Move static initializer call to GLProfile.getDefault to GLCanvas constructor.

### DIFF
--- a/src/jogl/classes/javax/media/opengl/awt/GLCanvas.java
+++ b/src/jogl/classes/javax/media/opengl/awt/GLCanvas.java
@@ -138,11 +138,9 @@ import com.jogamp.opengl.impl.ThreadingImpl;
 public class GLCanvas extends Canvas implements AWTGLAutoDrawable, WindowClosingProtocol {
 
   private static final boolean DEBUG;
-  private static final GLProfile defaultGLProfile;
 
   static {
       DEBUG = Debug.debug("GLCanvas");
-      defaultGLProfile = GLProfile.getDefault(GLProfile.getDefaultDesktopDevice());
   }
 
   private GLDrawableHelper drawableHelper = new GLDrawableHelper();
@@ -220,7 +218,7 @@ public class GLCanvas extends Canvas implements AWTGLAutoDrawable, WindowClosing
     super();
 
     if(null==capsReqUser) {
-        capsReqUser = new GLCapabilities(defaultGLProfile);
+        capsReqUser = new GLCapabilities(GLProfile.getDefault(GLProfile.getDefaultDesktopDevice()));
     } else {
         // don't allow the user to change data
         capsReqUser = (GLCapabilitiesImmutable) capsReqUser.cloneMutable();


### PR DESCRIPTION
As per my message to Sven, this change allows the GLCanvas class to be statically initialized (class init) without requiring the jogl/nativewindow native libraries to have been loaded.  This is desirable for our JOGL based library so that the native libraries can be loaded at runtime, without requiring them to be in the system or java library path.
