### PR TITLE
Add SWT to Eclipse classpath

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -34,5 +34,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/gluegen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Ant"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/SWT"/>
 	<classpathentry kind="output" path="build/eclipse-classes"/>
 </classpath>


### PR DESCRIPTION
This change allows you to run the JOGL SWT unit tests from inside Eclipse.
