### PR TITLE
Bug 471

### DIFF
--- a/src/newt/classes/com/jogamp/newt/util/MainThread.java
+++ b/src/newt/classes/com/jogamp/newt/util/MainThread.java
@@ -241,9 +241,9 @@ public class MainThread implements EDTUtil {
         if(null == cAWTEventQueue) {
             ClassLoader cl = MainThread.class.getClassLoader();
             cAWTEventQueue = ReflectionUtil.getClass("java.awt.EventQueue", true, cl);
-            mAWTInvokeAndWait = ReflectionUtil.getMethod(cAWTEventQueue, "invokeAndWait", new Class[] { java.lang.Runnable.class }, cl);
-            mAWTInvokeLater = ReflectionUtil.getMethod(cAWTEventQueue, "invokeLater", new Class[] { java.lang.Runnable.class }, cl);
-            mAWTIsDispatchThread = ReflectionUtil.getMethod(cAWTEventQueue, "isDispatchThread", new Class[] { }, cl);
+            mAWTInvokeAndWait = ReflectionUtil.getMethod(cAWTEventQueue, "invokeAndWait", new Class[] { java.lang.Runnable.class });
+            mAWTInvokeLater = ReflectionUtil.getMethod(cAWTEventQueue, "invokeLater", new Class[] { java.lang.Runnable.class });
+            mAWTIsDispatchThread = ReflectionUtil.getMethod(cAWTEventQueue, "isDispatchThread", new Class[] { });
         }
     }
 


### PR DESCRIPTION
MainThread#initAWTReflection() uses GlueGen's ReflectionUtil#getMethod(...), whose signature was recently changed to remove an unused ClassLoader.  The code in MainThread should be updated to reflect the change.

Because the parameter was unused, there should be no harm in simply removing the argument.

The corresponding GitHub commit was f92907d.  It can be found at:

https://github.com/sgothel/gluegen/commit/f92907da4946b29ca3b0132743f1cf0b7d59e080
