### PR TITLE
Bug 472

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -20,7 +20,7 @@
 			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="jogl/build/lib"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="com/jogamp/audio/windows/waveout/TestSpatialization.java|com/jogamp/opengl/impl/gl2/fixme/" kind="src" output="build/jogl/classes" path="src/jogl/classes">
+	<classpathentry excluding="com/jogamp/audio/windows/waveout/TestSpatialization.java|jogamp/opengl/gl2/fixme/" kind="src" output="build/jogl/classes" path="src/jogl/classes">
 		<attributes>
 			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="jogl/build/lib"/>
 		</attributes>


### PR DESCRIPTION
An excluded package was recently moved.  The Eclipse ".classpath" file should be updated to reflect the change.  Currently Eclipse will not compile the entire project because the package has errors.  Building on the command line using the Ant build file seems to be fine however.

The package was

```
com/jogamp/opengl/impl/gl2/fixme
```

but is now

```
jogamp/opengl/gl2/fixme
```
