### PR TITLE
Fix Eclipse .classpath to work cross-platform

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -31,6 +31,5 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/gluegen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Ant"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/SWT"/>
-	<classpathentry kind="lib" path="make/lib/swt/gtk-linux-x86_64/swt-debug.jar"/>
 	<classpathentry kind="output" path="build/eclipse-classes"/>
 </classpath>


### PR DESCRIPTION
Instead of putting the platform JAR in .classpath, you have to set up a user library called SWT (details at https://jogamp.org/wiki/index.php/Building_JOGL_in_Eclipse#Create_an_SWT_user_library). Sorry, Eclipse can be a pain sometimes :)
