### PR TITLE
Fix classpaths to work with Java 7's javah

### DIFF
--- a/make/build-nativewindow.xml
+++ b/make/build-nativewindow.xml
@@ -675,7 +675,7 @@
     </target>
 
     <target name="c.build.nativewindow.windowlib.windows" if="isWindows">
-      <javah destdir="${src.generated.c}/Windows" classpath="${classes}" class="jogamp.nativewindow.windows.GDI" />
+      <javah destdir="${src.generated.c}/Windows" classpath="${classes}:${gluegen.root}/build/classes" class="jogamp.nativewindow.windows.GDI" />
 
       <c.build c.compiler.src.files="c.src.files.windows"
                output.lib.name="nativewindow_win32"

--- a/make/build-newt.xml
+++ b/make/build-newt.xml
@@ -558,7 +558,7 @@
     <target name="c.build.newt.prepare">
       <javah destdir="${src.generated.c}/KD"          classpath="${gluegen-rt.jar}:${classes}" class="jogamp.newt.driver.kd.KDWindow" />
 
-      <javah destdir="${src.generated.c}/IntelGDL"    classpath="${gluegen-rt.jar}:${classes}" class="jogamp.newt.driver.intel.gdl.Display" />
+      <javah destdir="${src.generated.c}/IntelGDL"    classpath="${gluegen-rt.jar}:${classes}:${build}/nativewindow/classes" class="jogamp.newt.driver.intel.gdl.Display" />
       <javah destdir="${src.generated.c}/IntelGDL"    classpath="${gluegen-rt.jar}:${classes}" class="jogamp.newt.driver.intel.gdl.Screen" />
       <javah destdir="${src.generated.c}/IntelGDL"    classpath="${gluegen-rt.jar}:${classes}" class="jogamp.newt.driver.intel.gdl.Window" />
 


### PR DESCRIPTION
Java 7's javah requires all referenced classes to be classpath,
even if they're just method parameters and never instantiated.
Java 6's version of javah didn't require this.
