### PR TITLE
Newt openkode rename

### DIFF
--- a/make/build-newt.xml
+++ b/make/build-newt.xml
@@ -640,7 +640,7 @@
     </macrodef>
 
     <target name="c.build.newt.prepare">
-      <javah destdir="${src.generated.c}/KD"          classpath="${javah.classpath}" class="jogamp.newt.driver.kd.KDWindow" />
+      <javah destdir="${src.generated.c}/KD"          classpath="${javah.classpath}" class="jogamp.newt.driver.kd.Window" />
 
       <javah destdir="${src.generated.c}/IntelGDL"    classpath="${javah.classpath}" class="jogamp.newt.driver.intel.gdl.Display" />
       <javah destdir="${src.generated.c}/IntelGDL"    classpath="${javah.classpath}" class="jogamp.newt.driver.intel.gdl.Screen" />

--- a/src/newt/classes/jogamp/newt/DisplayImpl.java
+++ b/src/newt/classes/jogamp/newt/DisplayImpl.java
@@ -57,7 +57,7 @@ public abstract class DisplayImpl extends Display {
             if (NativeWindowFactory.TYPE_ANDROID == type) {
                 displayClass = Class.forName("jogamp.newt.driver.android.AndroidDisplay");
             } else if (NativeWindowFactory.TYPE_EGL == type) {
-                displayClass = Class.forName("jogamp.newt.driver.kd.KDDisplay");
+                displayClass = Class.forName("jogamp.newt.driver.kd.Display");
             } else if (NativeWindowFactory.TYPE_WINDOWS == type) {
                 displayClass = Class.forName("jogamp.newt.driver.windows.WindowsDisplay");
             } else if (NativeWindowFactory.TYPE_MACOSX == type) {

--- a/src/newt/classes/jogamp/newt/ScreenImpl.java
+++ b/src/newt/classes/jogamp/newt/ScreenImpl.java
@@ -98,7 +98,7 @@ public abstract class ScreenImpl extends Screen implements ScreenModeListener {
             if (NativeWindowFactory.TYPE_ANDROID == type) {
                 screenClass = Class.forName("jogamp.newt.driver.android.AndroidScreen");
             } else if (NativeWindowFactory.TYPE_EGL == type) {
-                screenClass = Class.forName("jogamp.newt.driver.kd.KDScreen");
+                screenClass = Class.forName("jogamp.newt.driver.kd.Screen");
             } else if (NativeWindowFactory.TYPE_WINDOWS == type) {
                 screenClass = Class.forName("jogamp.newt.driver.windows.WindowsScreen");
             } else if (NativeWindowFactory.TYPE_MACOSX == type) {

--- a/src/newt/classes/jogamp/newt/WindowImpl.java
+++ b/src/newt/classes/jogamp/newt/WindowImpl.java
@@ -157,7 +157,7 @@ public abstract class WindowImpl implements Window, NEWTEventConsumer
             if (NativeWindowFactory.TYPE_ANDROID == type) {
                 windowClass = Class.forName("jogamp.newt.driver.android.AndroidWindow");
             } else if (NativeWindowFactory.TYPE_EGL == type) {
-                windowClass = Class.forName("jogamp.newt.driver.kd.KDWindow");
+                windowClass = Class.forName("jogamp.newt.driver.kd.Window");
             } else if (NativeWindowFactory.TYPE_WINDOWS == type) {
                 windowClass = Class.forName("jogamp.newt.driver.windows.WindowsWindow");
             } else if (NativeWindowFactory.TYPE_MACOSX == type) {

--- a/src/newt/classes/jogamp/newt/driver/kd/Display.java
+++ b/src/newt/classes/jogamp/newt/driver/kd/Display.java
@@ -44,13 +44,13 @@ import jogamp.opengl.egl.EGLDisplayUtil;
 
 import com.jogamp.nativewindow.egl.EGLGraphicsDevice;
 
-public class KDDisplay extends DisplayImpl {
+public class Display extends DisplayImpl {
 
     static {
         NEWTJNILibLoader.loadNEWT();
 
-        if (!KDWindow.initIDs()) {
-            throw new NativeWindowException("Failed to initialize KDWindow jmethodIDs");
+        if (!Window.initIDs()) {
+            throw new NativeWindowException("Failed to initialize kd.Window jmethodIDs");
         }
     }
 
@@ -59,7 +59,7 @@ public class KDDisplay extends DisplayImpl {
     }
 
 
-    public KDDisplay() {
+    public Display() {
     }
 
     protected void createNativeImpl() {

--- a/src/newt/classes/jogamp/newt/driver/kd/Screen.java
+++ b/src/newt/classes/jogamp/newt/driver/kd/Screen.java
@@ -40,12 +40,12 @@ import javax.media.nativewindow.util.Point;
 
 import jogamp.newt.ScreenImpl;
 
-public class KDScreen extends ScreenImpl {
+public class Screen extends ScreenImpl {
     static {
-        KDDisplay.initSingleton();
+        Display.initSingleton();
     }
 
-    public KDScreen() {
+    public Screen() {
     }
 
     protected void createNativeImpl() {

--- a/src/newt/classes/jogamp/newt/driver/kd/Window.java
+++ b/src/newt/classes/jogamp/newt/driver/kd/Window.java
@@ -45,14 +45,14 @@ import javax.media.opengl.GLCapabilitiesImmutable;
 import jogamp.newt.WindowImpl;
 import jogamp.opengl.egl.EGLGraphicsConfiguration;
 
-public class KDWindow extends WindowImpl {
+public class Window extends WindowImpl {
     private static final String WINDOW_CLASS_NAME = "NewtWindow";
 
     static {
-        KDDisplay.initSingleton();
+        Display.initSingleton();
     }
 
-    public KDWindow() {
+    public Window() {
     }
 
     protected void createNativeImpl() {
@@ -151,7 +151,7 @@ public class KDWindow extends WindowImpl {
     @Override
     protected void sizeChanged(boolean defer, int newWidth, int newHeight, boolean force) {
         if(isFullscreen()) {
-            ((KDScreen)getScreen()).sizeChanged(getWidth(), getHeight());
+            ((Screen)getScreen()).sizeChanged(getWidth(), getHeight());
         }
         super.sizeChanged(defer, newWidth, newHeight, force);
     }

--- a/src/newt/native/KDWindow.c
+++ b/src/newt/native/KDWindow.c
@@ -44,7 +44,7 @@
 #include <KD/kd.h>
 #include <EGL/egl.h>
 
-#include "jogamp_newt_driver_kd_KDWindow.h"
+#include "jogamp_newt_driver_kd_Window.h"
 
 #include "MouseEvent.h"
 #include "KeyEvent.h"
@@ -82,7 +82,7 @@ static jmethodID sendKeyEventID = NULL;
  * Display
  */
 
-JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDDisplay_DispatchMessages
+JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_Display_DispatchMessages
   (JNIEnv *env, jobject obj)
 {
     const KDEvent * evt;
@@ -180,7 +180,7 @@ JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDDisplay_DispatchMessages
  * Window
  */
 
-JNIEXPORT jboolean JNICALL Java_jogamp_newt_driver_kd_KDWindow_initIDs
+JNIEXPORT jboolean JNICALL Java_jogamp_newt_driver_kd_Window_initIDs
   (JNIEnv *env, jclass clazz)
 {
 #ifdef VERBOSE_ON
@@ -208,7 +208,7 @@ JNIEXPORT jboolean JNICALL Java_jogamp_newt_driver_kd_KDWindow_initIDs
     return JNI_TRUE;
 }
 
-JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_KDWindow_CreateWindow
+JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_Window_CreateWindow
   (JNIEnv *env, jobject obj, jlong display, jlong jeglConfig)
 {
     EGLDisplay dpy  = (EGLDisplay)(intptr_t)display;
@@ -236,7 +236,7 @@ JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_KDWindow_CreateWindow
     return (jlong) (intptr_t) window;
 }
 
-JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_KDWindow_RealizeWindow
+JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_Window_RealizeWindow
   (JNIEnv *env, jobject obj, jlong window)
 {
     KDWindow *w = (KDWindow*) (intptr_t) window;
@@ -251,7 +251,7 @@ JNIEXPORT jlong JNICALL Java_jogamp_newt_driver_kd_KDWindow_RealizeWindow
     return (jlong) (intptr_t) nativeWindow;
 }
 
-JNIEXPORT jint JNICALL Java_jogamp_newt_driver_kd_KDWindow_CloseWindow
+JNIEXPORT jint JNICALL Java_jogamp_newt_driver_kd_Window_CloseWindow
   (JNIEnv *env, jobject obj, jlong window, jlong juserData)
 {
     KDWindow *w = (KDWindow*) (intptr_t) window;
@@ -265,11 +265,11 @@ JNIEXPORT jint JNICALL Java_jogamp_newt_driver_kd_KDWindow_CloseWindow
 }
 
 /*
- * Class:     jogamp_newt_driver_kd_KDWindow
+ * Class:     jogamp_newt_driver_kd_Window
  * Method:    setVisible0
  * Signature: (JJZ)V
  */
-JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDWindow_setVisible0
+JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_Window_setVisible0
   (JNIEnv *env, jobject obj, jlong window, jboolean visible)
 {
     KDWindow *w = (KDWindow*) (intptr_t) window;
@@ -279,7 +279,7 @@ JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDWindow_setVisible0
     (*env)->CallVoidMethod(env, obj, visibleChangedID, JNI_FALSE, visible); // FIXME: or defer=true ?
 }
 
-JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDWindow_setFullScreen0
+JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_Window_setFullScreen0
   (JNIEnv *env, jobject obj, jlong window, jboolean fullscreen)
 {
 /** not supported, due to missing NV property ..
@@ -296,7 +296,7 @@ JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDWindow_setFullScreen0
     (void)fullscreen;
 }
 
-JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_KDWindow_setSize0
+JNIEXPORT void JNICALL Java_jogamp_newt_driver_kd_Window_setSize0
   (JNIEnv *env, jobject obj, jlong window, jint width, jint height)
 {
     KDWindow *w = (KDWindow*) (intptr_t) window;


### PR DESCRIPTION
Rename jogamp.newt.driver.kd.\* classes to allow OpenKODE testing by passing
-cp jar/atomic/newt-driver-kd.jar -Dnativewindow.ws.name=jogamp.newt.driver.kd
