### PR TITLE
JNLP: Cache jogl-all-natives and jogl-cg-natives for linux-armv6 and lin...

### DIFF
--- a/jnlp-files/jogl-all-awt-cg.jnlp
+++ b/jnlp-files/jogl-all-awt-cg.jnlp
@@ -69,12 +69,16 @@
       <nativelib href = "jar/atomic/jogl-cg-natives-linux-amd64.jar" />
     </resources>
     <resources os="Linux" arch="arm">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
-      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
+      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv6.jar" />
+      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Linux" arch="armv7">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
-      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
+      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv6.jar" />
+      <nativelib href = "jar/atomic/jogl-cg-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Mac OS X" arch="i386">
       <nativelib href = "jar/jogl-all-natives-macosx-universal.jar" />

--- a/jnlp-files/jogl-all-awt.jnlp
+++ b/jnlp-files/jogl-all-awt.jnlp
@@ -56,10 +56,12 @@
       <nativelib href = "jar/jogl-all-natives-linux-amd64.jar" />
     </resources>
     <resources os="Linux" arch="arm">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Linux" arch="armv7">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Mac OS X" arch="i386">
       <nativelib href = "jar/jogl-all-natives-macosx-universal.jar" />

--- a/jnlp-files/jogl-all-mobile.jnlp
+++ b/jnlp-files/jogl-all-mobile.jnlp
@@ -56,10 +56,12 @@
       <nativelib href = "jar/jogl-all-natives-linux-amd64.jar" />
     </resources>
     <resources os="Linux" arch="arm">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Linux" arch="armv7">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Mac OS X" arch="i386">
       <nativelib href = "jar/jogl-all-natives-macosx-universal.jar" />

--- a/jnlp-files/jogl-all-noawt.jnlp
+++ b/jnlp-files/jogl-all-noawt.jnlp
@@ -56,10 +56,12 @@
       <nativelib href = "jar/jogl-all-natives-linux-amd64.jar" />
     </resources>
     <resources os="Linux" arch="arm">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Linux" arch="armv7">
-      <nativelib href = "jar/jogl-all-natives-linux-armv7.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6.jar" />
+      <nativelib href = "jar/jogl-all-natives-linux-armv6hf.jar" />
     </resources>
     <resources os="Mac OS X" arch="i386">
       <nativelib href = "jar/jogl-all-natives-macosx-universal.jar" />


### PR DESCRIPTION
...ux-armv6hf.

Gluegen commit gluegen/commit/422d7a5eb53fca6642ebf4e8910d8b0311bb2597
Change/Lower ARM Requierements for GNU/Linux
changed the _native-linux-arm_ jar names; update jnlp-files accordingly.

Due to the lack of OS Arch and ABI detection in JNLP launchers
force us download both armv6 armel and armv6hf armhf ABI jars on ARM.
