### PR TITLE
Fix the build on Fedora 17

### DIFF
--- a/make/build-common.xml
+++ b/make/build-common.xml
@@ -245,6 +245,7 @@
 
         <path id="gluegen-gl.classpath">
           <pathelement location="${gluegen.jar}" />
+          <pathelement location="${antlr.jar}" />
           <pathelement location="${gluegen-gl.jar}" />
         </path>
 


### PR DESCRIPTION
I got an issue while compiling jogl on a Fedora 17 box. antlr is needed to build  gluegen-gl, I just fix it on the gluegen-gl.classpath.
