### PR TITLE
Added OMXGLMediaPlayer back into codebase...

### DIFF
--- a/src/jogl/classes/com/jogamp/opengl/util/av/GLMediaPlayerFactory.java
+++ b/src/jogl/classes/com/jogamp/opengl/util/av/GLMediaPlayerFactory.java
@@ -36,6 +36,7 @@ import com.jogamp.common.util.ReflectionUtil;
 public class GLMediaPlayerFactory {
     private static final String AndroidGLMediaPlayerAPI14ClazzName = "jogamp.opengl.android.av.AndroidGLMediaPlayerAPI14";
     private static final String FFMPEGMediaPlayerClazzName = "jogamp.opengl.util.av.impl.FFMPEGMediaPlayer";
+    private static final String OMXGLMediaPlayerClazzName = "jogamp.opengl.util.av.impl.OMXGLMediaPlayer";
     private static final String isAvailableMethodName = "isAvailable";
     
     public static GLMediaPlayer create() {
@@ -45,6 +46,10 @@ public class GLMediaPlayerFactory {
                 if(((Boolean)ReflectionUtil.callStaticMethod(AndroidGLMediaPlayerAPI14ClazzName, isAvailableMethodName, null, null, cl)).booleanValue()) {
                     return (GLMediaPlayer) ReflectionUtil.createInstance(AndroidGLMediaPlayerAPI14ClazzName, cl);
                 }
+            }
+        } else if(Platform.OS_TYPE.equals(Platform.OSType.RASPBERRYPI)){
+            if(((Boolean)ReflectionUtil.callStaticMethod(OMXGLMediaPlayerClazzName, isAvailableMethodName, null, null, cl)).booleanValue()) {
+                return (GLMediaPlayer) ReflectionUtil.createInstance(OMXGLMediaPlayerClazzName, cl);
             }
         }
         if(((Boolean)ReflectionUtil.callStaticMethod(FFMPEGMediaPlayerClazzName, isAvailableMethodName, null, null, cl)).booleanValue()) {

--- a/src/nativewindow/classes/javax/media/nativewindow/NativeWindowFactory.java
+++ b/src/nativewindow/classes/javax/media/nativewindow/NativeWindowFactory.java
@@ -142,15 +142,13 @@ public abstract class NativeWindowFactory {
               return TYPE_WINDOWS;                
             case OPENKODE:
               return TYPE_EGL;
-                
+            case RASPBERRYPI:
+              return TYPE_BCM_VC_IV;
             case LINUX:
             case FREEBSD:
             case SUNOS:
             case HPUX:
             default:
-              if( guessBroadcomVCIV() ) {
-                return TYPE_BCM_VC_IV;
-              }
               return TYPE_X11;
         }
     }


### PR DESCRIPTION
Based on changes in gluegen to add RASPBERRYPI to Platform.OSType.

Removed RASPBERRYPI check in NativeWindowFactory and instead rely on the Platform.OSType.

Signed-off-by: Gabriel Reiser gabriel.reiser@mybrighthouse.com
