### PR TITLE
Fix Bug 821: GLProfile: computeProfileImpl GL4 & GL3 impl not valid for GL2ES2 profile.

### DIFF
--- a/src/jogl/classes/javax/media/opengl/GLProfile.java
+++ b/src/jogl/classes/javax/media/opengl/GLProfile.java
@@ -1891,19 +1891,9 @@ public class GLProfile {
             final boolean gles2Available = hasGLES3Impl && ( esCtxUndef || GLContext.isGLES2Available(device, es2HardwareRasterizer) );
             final boolean gles2HWAvailable = gles2Available && es2HardwareRasterizer[0] ;
             if(hasGL234Impl) {
-                if(GLContext.isGL4Available(device, isHardwareRasterizer)) {
-                    if(!gles2HWAvailable || isHardwareRasterizer[0]) {
-                        return GL4;
-                    }
-                }
                 if(GLContext.isGL4bcAvailable(device, isHardwareRasterizer)) {
                     if(!gles2HWAvailable || isHardwareRasterizer[0]) {
                         return GL4bc;
-                    }
-                }
-                if(GLContext.isGL3Available(device, isHardwareRasterizer)) {
-                    if(!gles2HWAvailable || isHardwareRasterizer[0]) {
-                        return GL3;
                     }
                 }
                 if(GLContext.isGL3bcAvailable(device, isHardwareRasterizer)) {


### PR DESCRIPTION
https://jogamp.org/bugzilla/show_bug.cgi?id=821

Signed-off-by: Xerxes Rånby xerxes@zafena.se
