### PR TITLE
Expand bitmasks in SWTAccessor GTK_VERSION method

### DIFF
--- a/src/nativewindow/classes/com/jogamp/nativewindow/swt/SWTAccessor.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/swt/SWTAccessor.java
@@ -114,9 +114,9 @@ public class SWTAccessor {
 
     private static VersionNumber GTK_VERSION(final int version) {
         // return (major << 16) + (minor << 8) + micro;
-        final int micro = ( version       ) & 0x0f;
-        final int minor = ( version >>  8 ) & 0x0f;
-        final int major = ( version >> 16 ) & 0x0f;
+        final int micro = ( version       ) & 0xff;
+        final int minor = ( version >>  8 ) & 0xff;
+        final int major = ( version >> 16 ) & 0xff;
         return new VersionNumber(major, minor, micro);
     }
 


### PR DESCRIPTION
SWTAccessor's GTK_VERSION method accepts a single int argument.  The
argument is interpreted as a bit-packed version number with the apparent
intent that the three least significant bytes of the int version number
are the major, minor, and micro version number components.

The code that extracts these three components from the int argument was
using four-bit mask 0x0f instead of eight-bit mask 0xff, and therefore
was discarding the four most significant bits of each component.  This
caused any component greater than 15 to lose information.  For example,
a component whose value should have been 20 would end up as 4.

The version number is used in comparisons in a static initializer to
determine how to retrieve references to Method objects via reflection.
One such comparison decides whether to retrieve a reference to method
GTK_WIDGET_WINDOW or method gtk_widget_get_window.

The problem initially presented itself after an attempt to use JOGL
with SWT 4.527 and GTK 2.20.1 because this version of SWT removed the
GTK_WIDGET_WINDOW method.  Due to the bug SWTAccessor believed the GTK
version was 2.4.1 instead of 2.20.1, so the code attempted to find
GTK_WIDGET_WINDOW instead of gtk_widget_get_window.  Because this
method was no longer there a runtime exception was raised.