### PR TITLE
Bug 1178 - Prevent dual mousepointers and improve raspberry pi xorg experience when using NEWT BCM VC IV on Raspberry Pi 

### DIFF
--- a/src/newt/classes/jogamp/newt/WindowImpl.java
+++ b/src/newt/classes/jogamp/newt/WindowImpl.java
@@ -2997,8 +2997,8 @@ public abstract class WindowImpl implements Window, NEWTEventConsumer
         final MouseEvent e;
         switch( eventType ) {
             case MouseEvent.EVENT_MOUSE_CLICKED:
-                e = null;
-                break;
+                // swallow CLICK event
+                return;
 
             case MouseEvent.EVENT_MOUSE_PRESSED:
                 if( 0 >= pPressure[0] ) {
@@ -3062,6 +3062,7 @@ public abstract class WindowImpl implements Window, NEWTEventConsumer
                 e = new MouseEvent(eventType, this, when, modifiers, pTypes, pID,
                                    pX, pY, pPressure, maxPressure, button, (short)0, rotationXYZ, rotationScale);
         }
+
         doEvent(enqueue, wait, e); // actual mouse event
     }
 

--- a/src/newt/classes/jogamp/newt/driver/KeyTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/KeyTracker.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 JogAmp Community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of JogAmp Community.
+ */
+
+package jogamp.newt.driver;
+
+import com.jogamp.newt.event.WindowListener;
+
+public interface KeyTracker extends WindowListener{
+
+}

--- a/src/newt/classes/jogamp/newt/driver/MouseTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/MouseTracker.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 JogAmp Community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of JogAmp Community.
+ */
+
+package jogamp.newt.driver;
+
+import com.jogamp.newt.event.WindowListener;
+
+public interface MouseTracker extends WindowListener {
+
+	int getLastY();
+
+	int getLastX();
+
+}

--- a/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
+++ b/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
@@ -34,6 +34,7 @@ import com.jogamp.nativewindow.Capabilities;
 import com.jogamp.nativewindow.DefaultGraphicsScreen;
 import com.jogamp.nativewindow.GraphicsConfigurationFactory;
 import com.jogamp.nativewindow.NativeWindowException;
+
 import com.jogamp.nativewindow.VisualIDHolder;
 import com.jogamp.nativewindow.util.Insets;
 import com.jogamp.nativewindow.util.Point;
@@ -41,12 +42,16 @@ import com.jogamp.nativewindow.util.Rectangle;
 import com.jogamp.nativewindow.util.RectangleImmutable;
 import com.jogamp.common.util.IntBitfield;
 import com.jogamp.nativewindow.egl.EGLGraphicsDevice;
+
 import com.jogamp.newt.event.MouseEvent;
 
 import jogamp.newt.PointerIconImpl;
 import jogamp.newt.WindowImpl;
+import jogamp.newt.driver.KeyTracker;
+import jogamp.newt.driver.MouseTracker;
 import jogamp.newt.driver.linux.LinuxEventDeviceTracker;
 import jogamp.newt.driver.linux.LinuxMouseTracker;
+import jogamp.newt.driver.x11.X11UnderlayTracker;
 import jogamp.opengl.egl.EGLDisplayUtil;
 
 public class WindowDriver extends WindowImpl {
@@ -57,8 +62,26 @@ public class WindowDriver extends WindowImpl {
     }
 
     public WindowDriver() {
-        linuxMouseTracker = LinuxMouseTracker.getSingleton();
-        linuxEventDeviceTracker = LinuxEventDeviceTracker.getSingleton();
+        
+    	/* Try use X11 as input for bcm.vc.iv
+    	 * if X11 fail to initialize then
+    	 * track using the /dev/event files directly
+    	 * using the LinuxMouseTracker
+    	 */
+        try{
+            x11UnderlayTracker = X11UnderlayTracker.getSingleton();
+
+            mouseTracker = x11UnderlayTracker;
+            keyTracker = x11UnderlayTracker;
+        } catch(ExceptionInInitializerError e){
+            linuxMouseTracker = LinuxMouseTracker.getSingleton();
+            linuxEventDeviceTracker = LinuxEventDeviceTracker.getSingleton();
+
+            mouseTracker = linuxMouseTracker;
+            keyTracker = linuxEventDeviceTracker;
+        }
+        
+        
         layer = -1;
         nativeWindowHandle = 0;
         windowHandleClose = 0;
@@ -192,8 +215,10 @@ public class WindowDriver extends WindowImpl {
         }
         windowHandleClose = nativeWindowHandle;
 
-        addWindowListener(linuxEventDeviceTracker);
-        addWindowListener(linuxMouseTracker);
+        addWindowListener(keyTracker);
+        addWindowListener(mouseTracker);
+
+        
         focusChanged(false, true);
     }
 
@@ -202,8 +227,8 @@ public class WindowDriver extends WindowImpl {
         final DisplayDriver display = (DisplayDriver) getScreen().getDisplay();
         final EGLGraphicsDevice eglDevice = (EGLGraphicsDevice) getGraphicsConfiguration().getScreen().getDevice();
 
-        removeWindowListener(linuxMouseTracker);
-        removeWindowListener(linuxEventDeviceTracker);
+        removeWindowListener(mouseTracker);
+        removeWindowListener(keyTracker);
 
         if(0!=windowHandleClose) {
             CloseWindow0(display.getBCMHandle(), windowHandleClose);
@@ -229,6 +254,7 @@ public class WindowDriver extends WindowImpl {
         final RectangleImmutable rect = clampRect((ScreenDriver) getScreen(), new Rectangle(x, y, width, height), false);
         // reconfigure0 will issue position/size changed events if required
         reconfigure0(nativeWindowHandle, rect.getX(), rect.getY(), rect.getWidth(), rect.getHeight(), flags);
+        
         return true;
     }
 
@@ -255,21 +281,25 @@ public class WindowDriver extends WindowImpl {
     @Override
     protected void setPointerIconImpl(final PointerIconImpl pi) {
         final DisplayDriver display = (DisplayDriver) getScreen().getDisplay();
-        display.setPointerIconActive(null != pi ? pi.validatedHandle() : 0, linuxMouseTracker.getLastX(), linuxMouseTracker.getLastY());
+        display.setPointerIconActive(null != pi ? pi.validatedHandle() : 0, mouseTracker.getLastX(), mouseTracker.getLastY());
     }
 
     @Override
     protected boolean setPointerVisibleImpl(final boolean pointerVisible) {
         final DisplayDriver display = (DisplayDriver) getScreen().getDisplay();
-        display.setActivePointerIconVisible(pointerVisible, linuxMouseTracker.getLastX(), linuxMouseTracker.getLastY());
+        display.setActivePointerIconVisible(pointerVisible, mouseTracker.getLastX(), mouseTracker.getLastY());
         return true;
     }
 
     //----------------------------------------------------------------------
     // Internals only
     //
-    private final LinuxMouseTracker linuxMouseTracker;
-    private final LinuxEventDeviceTracker linuxEventDeviceTracker;
+    private LinuxMouseTracker linuxMouseTracker;
+    private LinuxEventDeviceTracker linuxEventDeviceTracker;
+    private X11UnderlayTracker x11UnderlayTracker;
+    
+    private MouseTracker mouseTracker;
+    private KeyTracker keyTracker;
 
     protected static native boolean initIDs();
     private        native long CreateWindow0(long bcmDisplay, int layer, int x, int y, int width, int height, boolean opaque, int alphaBits);

--- a/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
+++ b/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
@@ -271,7 +271,7 @@ public class WindowDriver extends WindowImpl {
     @Override
     protected final void doMouseEvent(final boolean enqueue, final boolean wait, final short eventType, final int modifiers,
                                       final int x, final int y, final short button, final float[] rotationXYZ, final float rotationScale) {
-        if( MouseEvent.EVENT_MOUSE_MOVED == eventType ) {
+        if( MouseEvent.EVENT_MOUSE_MOVED == eventType || MouseEvent.EVENT_MOUSE_DRAGGED == eventType ) {
             final DisplayDriver display = (DisplayDriver) getScreen().getDisplay();
             display.moveActivePointerIcon(getX() + x, getY() + y);
         }

--- a/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
+++ b/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/WindowDriver.java
@@ -63,25 +63,24 @@ public class WindowDriver extends WindowImpl {
 
     public WindowDriver() {
         
-    	/* Try use X11 as input for bcm.vc.iv
-    	 * if X11 fail to initialize then
-    	 * track using the /dev/event files directly
-    	 * using the LinuxMouseTracker
-    	 */
+        /* Try use X11 as input for bcm.vc.iv
+         * if X11 fail to initialize then
+         * track using the /dev/event files directly
+         * using the LinuxMouseTracker
+         */
         try{
             x11UnderlayTracker = X11UnderlayTracker.getSingleton();
 
             mouseTracker = x11UnderlayTracker;
             keyTracker = x11UnderlayTracker;
-        } catch(ExceptionInInitializerError e){
+        } catch(ExceptionInInitializerError e) {
             linuxMouseTracker = LinuxMouseTracker.getSingleton();
             linuxEventDeviceTracker = LinuxEventDeviceTracker.getSingleton();
 
             mouseTracker = linuxMouseTracker;
             keyTracker = linuxEventDeviceTracker;
         }
-        
-        
+
         layer = -1;
         nativeWindowHandle = 0;
         windowHandleClose = 0;

--- a/src/newt/classes/jogamp/newt/driver/linux/LinuxEventDeviceTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/linux/LinuxEventDeviceTracker.java
@@ -40,6 +40,7 @@ import java.lang.Thread;
 import java.nio.ByteBuffer;
 
 import jogamp.newt.WindowImpl;
+import jogamp.newt.driver.KeyTracker;
 
 import com.jogamp.common.nio.StructAccessor;
 import com.jogamp.newt.Window;
@@ -55,7 +56,7 @@ import com.jogamp.newt.event.KeyEvent;
  * within it's own polling thread.
  */
 
-public class LinuxEventDeviceTracker implements WindowListener {
+public class LinuxEventDeviceTracker implements WindowListener, KeyTracker {
 
     private static final LinuxEventDeviceTracker ledt;
 

--- a/src/newt/classes/jogamp/newt/driver/linux/LinuxMouseTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/linux/LinuxMouseTracker.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import jogamp.newt.WindowImpl;
+import jogamp.newt.driver.MouseTracker;
 
 import com.jogamp.newt.Screen;
 import com.jogamp.newt.Window;
@@ -48,7 +49,7 @@ import com.jogamp.newt.event.WindowUpdateEvent;
  * just reading <code>/dev/input/mice</code>
  * within it's own polling thread.
  */
-public class LinuxMouseTracker implements WindowListener {
+public class LinuxMouseTracker implements WindowListener, MouseTracker {
 
     private static final LinuxMouseTracker lmt;
 

--- a/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
@@ -1,0 +1,328 @@
+/**
+ * Copyright 2015 JogAmp Community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of JogAmp Community.
+ */
+
+package jogamp.newt.driver.x11;
+
+import jogamp.nativewindow.x11.X11Util;
+import jogamp.newt.WindowImpl;
+import jogamp.newt.driver.MouseTracker;
+import jogamp.newt.driver.KeyTracker;
+
+import com.jogamp.common.util.ReflectionUtil;
+import com.jogamp.nativewindow.Capabilities;
+import com.jogamp.nativewindow.GraphicsConfigurationFactory;
+import com.jogamp.nativewindow.NativeWindowFactory;
+import com.jogamp.newt.Display;
+import com.jogamp.newt.NewtFactory;
+import com.jogamp.newt.Screen;
+import com.jogamp.newt.Window;
+import com.jogamp.newt.event.KeyEvent;
+import com.jogamp.newt.event.KeyListener;
+import com.jogamp.newt.event.MouseEvent;
+import com.jogamp.newt.event.MouseListener;
+import com.jogamp.newt.event.WindowEvent;
+import com.jogamp.newt.event.WindowListener;
+import com.jogamp.newt.event.WindowUpdateEvent;
+
+/**
+ * UnderlayTracker can be used as input for
+ * WM that only provide undecorated overlays.
+ * 
+ * The UnderlayTracker enable move and resize
+ * manipulation of the overlays.
+ * 
+ * A NEWT window may use the UnderlayTracker by calling
+ * <code>addWindowListener(X11UnderlayTracker.getSingleton())</code>
+ */
+public class X11UnderlayTracker implements WindowListener, KeyListener, MouseListener, MouseTracker, KeyTracker {
+
+    private static final X11UnderlayTracker tracker;
+    private static Window window;
+    private volatile WindowImpl focusedWindow = null;
+	private volatile MouseEvent lastMouse;
+
+    static {
+    	tracker = new X11UnderlayTracker();
+    }
+
+    public static X11UnderlayTracker getSingleton() {
+        return tracker;
+    }
+    
+    private X11UnderlayTracker() {
+    	
+    	/* 
+    	 * X11UnderlayTracker is intended to be used on systems where
+    	 * X11 is not the default WM.
+    	 * We must explicitly initialize all X11 dependencies
+    	 * to make sure they are available.
+    	 */
+    	X11Util.initSingleton();
+    	GraphicsConfigurationFactory.initSingleton();
+    	try {
+             ReflectionUtil.callStaticMethod("jogamp.nativewindow.x11.X11GraphicsConfigurationFactory",
+                                             "registerFactory", null, null, GraphicsConfigurationFactory.class.getClassLoader());
+        } catch (final Exception e) {
+                throw new RuntimeException(e);
+        }
+    	
+    	/*
+    	 * Initialize the X11 window.
+    	 */
+    	Capabilities caps = new Capabilities();
+        final Display display = NewtFactory.createDisplay(NativeWindowFactory.TYPE_X11, null, false);
+        final Screen screen  = NewtFactory.createScreen(display, 0);
+             	
+    	window = WindowImpl.create(null, 0, screen, caps);
+        //window.setSize(200, 140);
+        //window.setPosition(300, 400);
+        window.setVisible(false, true);
+        
+    	window.addKeyListener(this);
+        window.addMouseListener(this);
+        window.addWindowListener(this);
+    }
+
+
+
+    @Override
+    public void windowResized(final WindowEvent e) {
+    	final Object s = e.getSource();
+    	
+    	if(s instanceof WindowImpl) {
+    		if(window == s) {
+    			if(focusedWindow!=null){
+    				focusedWindow.setSize(window.getSurfaceWidth(),window.getSurfaceHeight());
+    				// workaround bvm.vc.iv possition gets moved during setSize
+    				focusedWindow.setPosition(window.getX(),window.getY());
+    			}
+    		} else {
+    			// FIXME null check here used as a workaround to prevent event avalance
+    			// fixing it will allow the user to resize the NEWT window using code
+    			// after it has gained focus.
+    			if(focusedWindow==null){
+    				WindowImpl sourceWindow = (WindowImpl) s;
+    				window.setSize(sourceWindow.getSurfaceWidth(),sourceWindow.getSurfaceHeight());
+    			}
+    		}
+        }
+    }
+
+    @Override
+    public void windowMoved(final WindowEvent e) {
+    	final Object s = e.getSource();
+    	if(s instanceof WindowImpl) {
+    		if(window == s) {
+    			if(focusedWindow!=null){
+    				//focusedWindow.setSize(window.getSurfaceWidth(),window.getSurfaceHeight());
+    				focusedWindow.setPosition(window.getX(), window.getY());
+    			}
+    		} else {
+    			// FIXME null check here used as a workaround to prevent event avalance
+    			// fixing it will allow the user to move the NEWT window using code
+    			// after it has gained focus.
+    			if(focusedWindow==null){
+    				WindowImpl sourceWindow = (WindowImpl) s;
+    				window.setPosition(sourceWindow.getX(), sourceWindow.getY());
+    			}
+    		}
+        }
+    }
+
+    @Override
+    public void windowDestroyNotify(final WindowEvent e) {
+        final Object s = e.getSource();
+        
+        if(window == s) {
+    		if(focusedWindow!=null){
+    			focusedWindow.destroy();
+    			focusedWindow = null;
+    		}
+    	} else {
+    		if(focusedWindow == s) {
+    			focusedWindow = null;
+    			window.setVisible(false, false);
+    			window.destroy();
+    		}
+    	}
+    }
+
+    @Override
+    public void windowDestroyed(final WindowEvent e) { }
+
+    @Override
+    public void windowGainedFocus(final WindowEvent e) {
+        final Object s = e.getSource();
+        if(s instanceof WindowImpl) {
+        	if(window == s) {
+        		// do nothing
+        	} else {
+        		if(focusedWindow==null) {
+        			// hack that initially make the tracking window the same size as the overlay
+        			WindowImpl sourceWindow = (WindowImpl) s;
+            		window.setSize(sourceWindow.getSurfaceWidth(),sourceWindow.getSurfaceHeight());
+            		window.setPosition(sourceWindow.getX(), sourceWindow.getY());
+        		}
+        		focusedWindow = (WindowImpl) s;
+        	}
+        }
+    }
+
+    @Override
+    public void windowLostFocus(final WindowEvent e) {
+        final Object s = e.getSource();
+    	if(window == s) {
+    		// do nothing
+    	} else {
+    		if(focusedWindow == s) {
+    			focusedWindow = null;
+    		}
+    	}
+    }
+
+    @Override
+    public void windowRepaint(final WindowUpdateEvent e) { }
+    
+    public static void main(String[] args) throws InterruptedException{
+    	X11UnderlayTracker.getSingleton();
+        
+    	Thread.sleep(25000);
+    }
+
+	@Override
+	public void mouseClicked(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_CLICKED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseEntered(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_ENTERED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseExited(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_EXITED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mousePressed(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+            //e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_PRESSED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseReleased(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_RELEASED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseMoved(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_MOVED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseDragged(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_DRAGGED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void mouseWheelMoved(MouseEvent e) {
+		lastMouse = e;
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_WHEEL_MOVED, 0, e.getX(), e.getY(), (short)0, 0 );
+		}
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e) {
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendKeyEvent(e.getEventType(), e.getModifiers(), e.getKeyCode(), e.getKeyCode(), (char)e.getKeySymbol());
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e) {
+		if(focusedWindow != null){
+			//e.setConsumed(false);
+			//focusedWindow.consumeEvent(e);
+			focusedWindow.sendKeyEvent(e.getEventType(), e.getModifiers(), e.getKeyCode(), e.getKeyCode(), (char)e.getKeySymbol());
+		}
+	}
+
+	@Override
+	public int getLastY() {
+        if(lastMouse!=null)
+            return lastMouse.getY();
+		return 0;
+	}
+
+	@Override
+	public int getLastX() {
+        if(lastMouse!=null)
+            return lastMouse.getX();	
+		return 0;
+	}
+}

--- a/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
@@ -202,6 +202,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
 
                 underlayWindow.setTitle(overlayWindow.getTitle());
 
+                if(overlayWindow.isUndecorated()){
+                    underlayWindow.setUndecorated(true);
+                }
+
                 underlayWindow.addKeyListener(this);
                 underlayWindow.addMouseListener(this);
                 underlayWindow.addWindowListener(this);
@@ -247,7 +251,7 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
         w.setVisible(true);
 
         w = NewtFactory.createWindow(caps);
-        w.setUndecorated(true);
+        w.setUndecorated(false);
         w.addWindowListener(X11UnderlayTracker.getSingleton());
         w.setTitle("2");
         w.setVisible(true);

--- a/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
@@ -63,7 +63,7 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
                                            MouseTracker, KeyTracker {
 
     private static final X11UnderlayTracker tracker;
-    private volatile WindowImpl focusedWindow = null; // Mouse & Key events is sent to the focusedWindow
+    private volatile WindowImpl focusedWindow = null; // Key events is sent to the focusedWindow
     private volatile MouseEvent lastMouse;
     private volatile static ArrayHashMap<WindowImpl, WindowImpl> underlayWindowMap = new ArrayHashMap<WindowImpl, WindowImpl>(false, ArrayHashMap.DEFAULT_INITIAL_CAPACITY, ArrayHashMap.DEFAULT_LOAD_FACTOR);
     private volatile static ArrayHashMap<WindowImpl, WindowImpl> overlayWindowMap = new ArrayHashMap<WindowImpl, WindowImpl>(false, ArrayHashMap.DEFAULT_INITIAL_CAPACITY, ArrayHashMap.DEFAULT_LOAD_FACTOR);
@@ -94,23 +94,21 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void windowResized(final WindowEvent e) {
         final Object s = e.getSource();
-        if (s instanceof WindowImpl) {
-            if (underlayWindowMap.containsKey(s)) {
-                WindowImpl underlayWindow = (WindowImpl)s;
-                WindowImpl overlayWindow = underlayWindowMap.get(s);
-                if(overlayWindow.getSurfaceWidth() != underlayWindow.getSurfaceWidth() ||
-                   overlayWindow.getSurfaceHeight() != underlayWindow.getSurfaceHeight()) {
-                   overlayWindow.setSize(underlayWindow.getSurfaceWidth(),
-                                         underlayWindow.getSurfaceHeight());
-                }
-            } else if (overlayWindowMap.containsKey(s)){
-                WindowImpl overlayWindow = (WindowImpl)s;
-                WindowImpl underlayWindow = overlayWindowMap.get(s);
-                if(overlayWindow.getSurfaceWidth() != underlayWindow.getSurfaceWidth() ||
-                   overlayWindow.getSurfaceHeight() != underlayWindow.getSurfaceHeight()) {
-                    underlayWindow.setSize(overlayWindow.getSurfaceWidth(),
-                                           overlayWindow.getSurfaceHeight());
-                }
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl underlayWindow = (WindowImpl)s;
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            if(overlayWindow.getSurfaceWidth() != underlayWindow.getSurfaceWidth() ||
+               overlayWindow.getSurfaceHeight() != underlayWindow.getSurfaceHeight()) {
+               overlayWindow.setSize(underlayWindow.getSurfaceWidth(),
+                                     underlayWindow.getSurfaceHeight());
+            }
+        } else if (overlayWindowMap.containsKey(s)){
+            WindowImpl overlayWindow = (WindowImpl)s;
+            WindowImpl underlayWindow = overlayWindowMap.get(s);
+            if(overlayWindow.getSurfaceWidth() != underlayWindow.getSurfaceWidth() ||
+               overlayWindow.getSurfaceHeight() != underlayWindow.getSurfaceHeight()) {
+                underlayWindow.setSize(overlayWindow.getSurfaceWidth(),
+                                       overlayWindow.getSurfaceHeight());
             }
         }
     }
@@ -118,21 +116,19 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void windowMoved(final WindowEvent e) {
         final Object s = e.getSource();
-        if (s instanceof WindowImpl) {
-            if (underlayWindowMap.containsKey(s)) {
-                WindowImpl underlayWindow = (WindowImpl)s;
-                WindowImpl overlayWindow = underlayWindowMap.get(s);
-                if(overlayWindow.getX()!=underlayWindow.getX() ||
-                   overlayWindow.getY()!=underlayWindow.getY()) {
-                    overlayWindow.setPosition(underlayWindow.getX(), underlayWindow.getY());
-                }
-            } else if (overlayWindowMap.containsKey(s)) {
-                WindowImpl overlayWindow = (WindowImpl)s;
-                WindowImpl underlayWindow = overlayWindowMap.get(s);
-                if(overlayWindow.getX()!=underlayWindow.getX() ||
-                   overlayWindow.getY()!=underlayWindow.getY()) {
-                    underlayWindow.setPosition(overlayWindow.getX(), overlayWindow.getY());
-                }
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl underlayWindow = (WindowImpl)s;
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            if(overlayWindow.getX()!=underlayWindow.getX() ||
+               overlayWindow.getY()!=underlayWindow.getY()) {
+                overlayWindow.setPosition(underlayWindow.getX(), underlayWindow.getY());
+            }
+        } else if (overlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = (WindowImpl)s;
+            WindowImpl underlayWindow = overlayWindowMap.get(s);
+            if(overlayWindow.getX()!=underlayWindow.getX() ||
+               overlayWindow.getY()!=underlayWindow.getY()) {
+                underlayWindow.setPosition(overlayWindow.getX(), overlayWindow.getY());
             }
         }
     }
@@ -191,7 +187,7 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
 
                 final Display display = NewtFactory.createDisplay(NativeWindowFactory.TYPE_X11, null, false);
                 final Screen screen = NewtFactory.createScreen(display, 0);
-                WindowImpl underlayWindow = WindowImpl.create(null, 0, screen, caps);                
+                WindowImpl underlayWindow = WindowImpl.create(null, 0, screen, caps);
 
                 /*
                  * Register overlay and under-lay window in the map's before generating events.
@@ -262,10 +258,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseClicked(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_CLICKED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_CLICKED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -273,10 +269,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseEntered(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_ENTERED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_ENTERED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -284,10 +280,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseExited(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_EXITED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_EXITED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -295,10 +291,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mousePressed(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_PRESSED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_PRESSED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -306,10 +302,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseReleased(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_RELEASED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_RELEASED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -317,10 +313,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseMoved(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_MOVED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_MOVED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -328,10 +324,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseDragged(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_DRAGGED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_DRAGGED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }
@@ -339,10 +335,10 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
     @Override
     public void mouseWheelMoved(MouseEvent e) {
         lastMouse = e;
-        if (focusedWindow != null) {
-            // e.setConsumed(false);
-            // focusedWindow.consumeEvent(e);
-            focusedWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_WHEEL_MOVED, 0,
+        final Object s = e.getSource();
+        if (underlayWindowMap.containsKey(s)) {
+            WindowImpl overlayWindow = underlayWindowMap.get(s);
+            overlayWindow.sendMouseEvent(MouseEvent.EVENT_MOUSE_WHEEL_MOVED, 0,
                                          e.getX(), e.getY(), (short) 0, 0);
         }
     }

--- a/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
+++ b/src/newt/classes/jogamp/newt/driver/x11/X11UnderlayTracker.java
@@ -128,7 +128,9 @@ public class X11UnderlayTracker implements WindowListener, KeyListener, MouseLis
             WindowImpl underlayWindow = overlayWindowMap.get(s);
             if(overlayWindow.getX()!=underlayWindow.getX() ||
                overlayWindow.getY()!=underlayWindow.getY()) {
-                underlayWindow.setPosition(overlayWindow.getX(), overlayWindow.getY());
+                //FIXME: Pressing Maximize on the underlay X11
+                //with this line enabled locks-up the NEWT EDT while using the BCM.VC.IV
+                //underlayWindow.setPosition(overlayWindow.getX(), overlayWindow.getY());
             }
         }
     }


### PR DESCRIPTION
Bug 1178: Implement X11UnderlayTracker

Fixed corner cases cc0, cc4, cc7 and cc8
Bug 1178: Fix cc0 WindowImpl: Swallow CLICK event
Bug 1178: X11UnderlayTracker Fix cc4. Attempted fix for cc6.
Bug 1178: Fix cc8 bcm.vc.iv WindowDriver: Update pointer during DRAGGED events.
Bug 1178: Fix cc7 X11UnderlayTracker can now track multiple windows.
Bug 1178: Mouse events shall be passed on to unfocused overlays.
Bug 1178: if overlay is undecorated then make under-lay the same

Unfixed corner cases:
cc1: if you minimize the X11 window the overlay is still visible
Fix for cc1 requires that NEWT can send minimize events.

cc2: if you move the X11 window outside the visible screen then the overlay gets recentered by bcm.vc.iv code to be inside the screen.
Fix for cc2 require that the bcm.vc.iv driver send a new WindowEvent when it have re-centered inside the screen.

cc3: when you resize the x11 window then the overlay gets resized but get a new position (bug in bcm.vc.iv driver)

cc5: re-use the x11 newt events as is then it would support multiple mousepointers etc

cc6: if you render the bcm.vc.iv window transparent -> caps.setBackgroundOpaque(false); then you will see that the tracker window newer repaints -> looks a bit like a mess
Fix for cc6 require that the X11UnderlayTracker NEWT windows gets repainted with a transparent color.