### PR TITLE
SWTAccessor: Cleanup disable debug messages

### DIFF
--- a/src/nativewindow/classes/com/jogamp/nativewindow/swt/SWTAccessor.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/swt/SWTAccessor.java
@@ -51,9 +51,10 @@ import com.jogamp.nativewindow.x11.X11GraphicsDevice;
 
 import jogamp.nativewindow.macosx.OSXUtil;
 import jogamp.nativewindow.x11.X11Lib;
+import jogamp.nativewindow.Debug;
 
 public class SWTAccessor {
-    private static final boolean DEBUG = true;
+    private static final boolean DEBUG = Debug.debug("SWT");
 
     private static final Field swt_control_handle;
     private static final boolean swt_uses_long_handles;


### PR DESCRIPTION
Variable DEBUG was set permanently to 'true' which caused single-line err output during construction of com.jogamp.opengl.swt.GLCanvas.
The message should be conditional, controlled by property, checked with nativewindow.Debug.

PS1. haven't tested if it compiles; don't have the env at the moment
PS2. not sure if "SWT" is suitable as sub-component string
