### PR TITLE
Change BCM VC IV detection to handle presence of vc4 DRI module

### DIFF
--- a/src/nativewindow/classes/com/jogamp/nativewindow/NativeWindowFactory.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/NativeWindowFactory.java
@@ -140,9 +140,11 @@ public abstract class NativeWindowFactory {
         return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
             private final File vcliblocation = new File(
                     "/opt/vc/lib/libbcm_host.so");
+            private final File vc4modlocation = new File(
+                    "/sys/module/vc4");
                 @Override
                 public Boolean run() {
-                    if ( vcliblocation.isFile() ) {
+                    if ( vcliblocation.isFile() && !vc4modlocation.isDirectory() ) {
                         return Boolean.TRUE;
                     }
                     return Boolean.FALSE;


### PR DESCRIPTION
The recent Raspbian release comes with a vc4 kernel module that can be activated with a device tree overlay. In this case, we want to use the DRI & Mesa / Gallium3D driver instead of the BCM VC IV one, whose userspace library remains in /opt/vc.
