### PR TITLE
Fix viewport height in BCM VC IV ScreenDriver

### DIFF
--- a/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/ScreenDriver.java
+++ b/src/newt/classes/jogamp/newt/driver/bcm/vc/iv/ScreenDriver.java
@@ -84,11 +84,11 @@ public class ScreenDriver extends ScreenImpl {
         props[i++] = 0; // rotated viewport x pixel-units
         props[i++] = 0; // rotated viewport y pixel-units
         props[i++] = cachedWidth; // rotated viewport width pixel-units
-        props[i++] = cachedWidth; // rotated viewport height pixel-units
+        props[i++] = cachedHeight; // rotated viewport height pixel-units
         props[i++] = 0; // rotated viewport x window-units
         props[i++] = 0; // rotated viewport y window-units
         props[i++] = cachedWidth; // rotated viewport width window-units
-        props[i++] = cachedWidth; // rotated viewport height window-units
+        props[i++] = cachedHeight; // rotated viewport height window-units
         MonitorModeProps.streamInMonitorDevice(cache, this, currentMode, null, cache.monitorModes, props, 0, null);
     }
 


### PR DESCRIPTION
This should fix https://jogamp.org/bugzilla/show_bug.cgi?id=1254, which leads to windowed sketches not being centered in Processing.
