### PR TITLE
VC4: Broadcom uses libbrcmEGL.so, libbrcmGLESv2.so, libbrcmOpenVG.so …

### DIFF
--- a/src/jogl/classes/jogamp/opengl/egl/EGLDynamicLibraryBundleInfo.java
+++ b/src/jogl/classes/jogamp/opengl/egl/EGLDynamicLibraryBundleInfo.java
@@ -34,6 +34,8 @@ import java.util.List;
 import jogamp.common.os.PlatformPropsImpl;
 import jogamp.opengl.GLDynamicLibraryBundleInfo;
 
+import jogamp.nativewindow.BcmVCArtifacts;
+
 import com.jogamp.common.os.AndroidVersion;
 import com.jogamp.common.os.Platform;
 import com.jogamp.opengl.egl.EGL;
@@ -97,8 +99,16 @@ public abstract class EGLDynamicLibraryBundleInfo extends GLDynamicLibraryBundle
     protected final List<String> getEGLLibNamesList() {
         final List<String> eglLibNames = new ArrayList<String>();
 
+	/**
+          * Prefer libbrcmEGL.so over libEGL.so.1 for proprietary
+          * Broadcom graphics when the VC4 DRM Xorg driver isn't present
+          */
+        final boolean bcm_vc_iv_quirk = BcmVCArtifacts.guessVCIVUsed(false);
+
         // this is the default EGL lib name, according to the spec
-        eglLibNames.add("libEGL.so.1");
+        if(!bcm_vc_iv_quirk) {
+            eglLibNames.add("libEGL.so.1");
+        }
 
         // try these as well, if spec fails
         eglLibNames.add("libEGL.so");
@@ -107,6 +117,10 @@ public abstract class EGLDynamicLibraryBundleInfo extends GLDynamicLibraryBundle
         // for windows distributions using the 'unlike' lib prefix,
         // where our tool does not add it.
         eglLibNames.add("libEGL");
+
+	if(bcm_vc_iv_quirk) {
+            eglLibNames.add("libbrcmEGL.so");
+	}
 
         return eglLibNames;
     }

--- a/src/jogl/classes/jogamp/opengl/egl/EGLDynamicLibraryBundleInfo.java
+++ b/src/jogl/classes/jogamp/opengl/egl/EGLDynamicLibraryBundleInfo.java
@@ -105,22 +105,20 @@ public abstract class EGLDynamicLibraryBundleInfo extends GLDynamicLibraryBundle
           */
         final boolean bcm_vc_iv_quirk = BcmVCArtifacts.guessVCIVUsed(false);
 
-        // this is the default EGL lib name, according to the spec
         if(!bcm_vc_iv_quirk) {
+            // this is the default EGL lib name, according to the spec
             eglLibNames.add("libEGL.so.1");
-        }
 
-        // try these as well, if spec fails
-        eglLibNames.add("libEGL.so");
-        eglLibNames.add("EGL");
+            // try these as well, if spec fails
+            eglLibNames.add("libEGL.so");
+            eglLibNames.add("EGL");
 
-        // for windows distributions using the 'unlike' lib prefix,
-        // where our tool does not add it.
-        eglLibNames.add("libEGL");
-
-	if(bcm_vc_iv_quirk) {
+            // for windows distributions using the 'unlike' lib prefix,
+            // where our tool does not add it.
+            eglLibNames.add("libEGL");
+        } else {
             eglLibNames.add("libbrcmEGL.so");
-	}
+        }
 
         return eglLibNames;
     }

--- a/src/jogl/classes/jogamp/opengl/egl/EGLES2DynamicLibraryBundleInfo.java
+++ b/src/jogl/classes/jogamp/opengl/egl/EGLES2DynamicLibraryBundleInfo.java
@@ -57,43 +57,41 @@ public final class EGLES2DynamicLibraryBundleInfo extends EGLDynamicLibraryBundl
              */
             final boolean bcm_vc_iv_quirk = BcmVCArtifacts.guessVCIVUsed(false);
 
-            // ES3: This is the default lib name, according to the spec
-            libsGL.add("libGLESv3.so.3");
-
-            // ES3: Try these as well, if spec fails
-            libsGL.add("libGLESv3.so");
-            libsGL.add("GLESv3");
-
-            // ES3: Alternative names
-            libsGL.add("GLES30");
-
-            // ES3: For windows distributions using the 'unlike' lib prefix
-            // where our tool does not add it.
-            libsGL.add("libGLESv3");
-            libsGL.add("libGLES30");
-
-            // ES2: This is the default lib name, according to the spec
-            if (!bcm_vc_iv_quirk) {
-                libsGL.add("libGLESv2.so.2");
-            }
-
-            // ES2: Try these as well, if spec fails
-            libsGL.add("libGLESv2.so");
-            libsGL.add("GLESv2");
-
             if (bcm_vc_iv_quirk) {
                 libsGL.add("libbrcmGLESv2.so");
+            } else {
+                // ES3: This is the default lib name, according to the spec
+                libsGL.add("libGLESv3.so.3");
+
+                // ES3: Try these as well, if spec fails
+                libsGL.add("libGLESv3.so");
+                libsGL.add("GLESv3");
+
+                // ES3: Alternative names
+                libsGL.add("GLES30");
+
+                // ES3: For windows distributions using the 'unlike' lib prefix
+                // where our tool does not add it.
+                libsGL.add("libGLESv3");
+                libsGL.add("libGLES30");
+
+                // ES2: This is the default lib name, according to the spec
+                libsGL.add("libGLESv2.so.2");
+
+                // ES2: Try these as well, if spec fails
+                libsGL.add("libGLESv2.so");
+                libsGL.add("GLESv2");
+
+                // ES2: Alternative names
+                libsGL.add("GLES20");
+                libsGL.add("GLESv2_CM");
+
+                // ES2: For windows distributions using the 'unlike' lib prefix
+                // where our tool does not add it.
+                libsGL.add("libGLESv2");
+                libsGL.add("libGLESv2_CM");
+                libsGL.add("libGLES20");
             }
-
-            // ES2: Alternative names
-            libsGL.add("GLES20");
-            libsGL.add("GLESv2_CM");
-
-            // ES2: For windows distributions using the 'unlike' lib prefix
-            // where our tool does not add it.
-            libsGL.add("libGLESv2");
-            libsGL.add("libGLESv2_CM");
-            libsGL.add("libGLES20");
 
             libsList.add(libsGL);
         }

--- a/src/jogl/classes/jogamp/opengl/egl/EGLES2DynamicLibraryBundleInfo.java
+++ b/src/jogl/classes/jogamp/opengl/egl/EGLES2DynamicLibraryBundleInfo.java
@@ -52,7 +52,7 @@ public final class EGLES2DynamicLibraryBundleInfo extends EGLDynamicLibraryBundl
             final List<String> libsGL = new ArrayList<String>();
 
             /**
-             * Prefer libGLESv2.so over libGLESv2.so.2 for proprietary
+             * Prefer libbrcmGLESv2.so over libGLESv2.so.2 for proprietary
              * Broadcom graphics when the VC4 DRM Xorg driver isn't present
              */
             final boolean bcm_vc_iv_quirk = BcmVCArtifacts.guessVCIVUsed(false);
@@ -82,7 +82,7 @@ public final class EGLES2DynamicLibraryBundleInfo extends EGLDynamicLibraryBundl
             libsGL.add("GLESv2");
 
             if (bcm_vc_iv_quirk) {
-                libsGL.add("libGLESv2.so.2");
+                libsGL.add("libbrcmGLESv2.so");
             }
 
             // ES2: Alternative names

--- a/src/nativewindow/classes/com/jogamp/nativewindow/NativeWindowFactory.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/NativeWindowFactory.java
@@ -174,7 +174,20 @@ public abstract class NativeWindowFactory {
                   guessGBM(true);
                   BcmVCArtifacts.guessVCIVUsed(true);
               }
-
+              if( BcmVCArtifacts.guessVCIVUsed(false) ) {
+                 /* Broadcom VC IV can be used from
+                  * both console and from inside X11
+                  *
+                  * When used from inside X11
+                  * rendering is done on an DispmanX overlay surface
+                  * while keeping an X11 nativewindow under as input.
+                  *
+                  * When Broadcom VC IV is guessed
+                  * only the Broadcom DispmanX EGL driver is loaded.
+                  * Therefore standard TYPE_X11 EGL can not be used.
+                  */
+                  return TYPE_BCM_VC_IV;
+              }
               if( guessX(false) ) {
                   return TYPE_X11;
               }
@@ -184,9 +197,6 @@ public abstract class NativeWindowFactory {
               }
               if( guessGBM(false) ) {
                   return TYPE_DRM_GBM;
-              }
-              if( BcmVCArtifacts.guessVCIVUsed(false) ) {
-                  return TYPE_BCM_VC_IV;
               }
               return TYPE_X11;
         }


### PR DESCRIPTION
This pullrequest enable detection and hardware acceleration for 
-     armv6hf Broadcom DispmanX
-     armv6hf Broadcom DispmanX overlay on top of X11
https://jogamp.org/wiki/index.php?title=Raspberry_Pi

+++++

VC4: Broadcom uses libbrcmEGL.so, libbrcmGLESv2.so, libbrcmOpenVG.so and libbrcmWFC.so since 7 Jul 2016

Raspbian integration (two libGLES side-by-side)
https://github.com/anholt/mesa/issues/24

Old library names before 7 Jul 2016 can not be included because it would pull in libEGL.so.1 and cause JogAmp to choose software rendering using "llvm pipe" from mesa.

+++++

VC4: Only load Broadcom EGL driver when guessVCIVUsed

Broadcom VC IV can be used from
both console and from inside X11

When used from inside X11
rendering is done on an DispmanX overlay surface
while keeping an X11 nativewindow under as input.

When Broadcom VC IV is guessed
only the Broadcom DispmanX EGL driver is loaded.
Therefore standard TYPE_X11 EGL can not be used.