### PR TITLE
Return either glXQueryClientString or glXQueryExtensionsString when getting the GLX extensions

### DIFF
--- a/src/jogl/classes/jogamp/opengl/x11/glx/X11GLXContext.java
+++ b/src/jogl/classes/jogamp/opengl/x11/glx/X11GLXContext.java
@@ -551,24 +551,16 @@ public class X11GLXContext extends GLContextImpl {
                              ", server: "+ GLXUtil.getGLXServerVersionNumber(x11Device));
         }
         if(((X11GLXDrawableFactory)drawable.getFactoryImpl()).isGLXVersionGreaterEqualOneOne(x11Device)) {
-            {
+            if (ns.getScreenIndex() < 0) {
                 final String ret = GLX.glXGetClientString(x11Device.getHandle(), GLX.GLX_EXTENSIONS);
                 if (DEBUG) {
                   System.err.println("GLX extensions (glXGetClientString): " + ret);
                 }
                 sb.append(ret).append(" ");
-            }
-            {
+            } else {
                 final String ret = GLX.glXQueryExtensionsString(x11Device.getHandle(), ns.getScreenIndex());
                 if (DEBUG) {
                   System.err.println("GLX extensions (glXQueryExtensionsString): " + ret);
-                }
-                sb.append(ret).append(" ");
-            }
-            {
-                final String ret = GLX.glXQueryServerString(x11Device.getHandle(), ns.getScreenIndex(), GLX.GLX_EXTENSIONS);
-                if (DEBUG) {
-                  System.err.println("GLX extensions (glXQueryServerString): " + ret);
                 }
                 sb.append(ret).append(" ");
             }


### PR DESCRIPTION
glXQueryExtensionsString will make a request for glXQueryServerString if needed and will append the necessary client-side extensions (more information in this [doc]( http://titan.cs.ukzn.ac.za/opengl/opengl-d5/trant.sgi.com/opengl/docs/extensions/extensions.html), under the section "Extension availability").

This [doc](https://www.khronos.org/registry/OpenGL/docs/rules.html), under the section "Using GLS Extensions", also suggests checking the glXQueryExtensionsString before using GLX extensions.