### PR TITLE
Enable GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: sgothel


### PR DESCRIPTION
Adds a `FUNDING.yml` file that enables a sponsor button to become visible in the top of the repository. This button links to the [sponsor page](https://github.com/sponsors/sgothel/) and thus makes the possibility to donate easier and more visible.

See [Displaying a sponsor button in your repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).

Thanks for all the hard work on JOGL!