### PR TITLE
Set JAWTWindow:reqPixelScale before the DPI scaling factor is determined and fix AUTOMAX_PIXELSCALE 

### DIFF
--- a/src/jogl/classes/com/jogamp/opengl/awt/GLCanvas.java
+++ b/src/jogl/classes/com/jogamp/opengl/awt/GLCanvas.java
@@ -721,9 +721,9 @@ public class GLCanvas extends Canvas implements AWTGLAutoDrawable, WindowClosing
          */
         jawtWindow = (JAWTWindow) NativeWindowFactory.getNativeWindow(this, awtConfig);
         jawtWindow.setShallUseOffscreenLayer(shallUseOffscreenLayer);
+        jawtWindow.setSurfaceScale(reqPixelScale);
         jawtWindow.lockSurface();
         try {
-            jawtWindow.setSurfaceScale(reqPixelScale);
             drawable = (GLDrawableImpl) GLDrawableFactory.getFactory(capsReqUser.getGLProfile()).createGLDrawable(jawtWindow);
             createContextImpl(drawable);
             jawtWindow.getCurrentSurfaceScale(hasPixelScale);

--- a/src/nativewindow/classes/com/jogamp/nativewindow/awt/JAWTWindow.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/awt/JAWTWindow.java
@@ -392,7 +392,13 @@ public abstract class JAWTWindow implements NativeWindow, OffscreenLayerSurface,
   public final boolean updatePixelScale(final GraphicsConfiguration gc, final boolean clearFlag) {
       if( JAWTUtil.getPixelScale(gc, minPixelScale, maxPixelScale) ) {
           hasPixelScaleChanged = true;
-          System.arraycopy(maxPixelScale, 0, hasPixelScale, 0, 2);
+          for (int i=0; i < reqPixelScale.length; i++) {
+        	  if (reqPixelScale[i] == ScalableSurface.AUTOMAX_PIXELSCALE)
+        		  hasPixelScale[i] = maxPixelScale[i];
+        	  else
+        		  hasPixelScale[i] = reqPixelScale[i];
+          }
+
           if( DEBUG ) {
               System.err.println("JAWTWindow.updatePixelScale: updated req["+
                       reqPixelScale[0]+", "+reqPixelScale[1]+"], min["+


### PR DESCRIPTION
Set JAWTWindow:reqPixelScale before the DPI scaling factor is determined, so if GLCanvas.setSurfaceScale() has been called, the correct 'reqPixelScale' is available.  It's possible to call GLCanvas.setSurfaceScale() before JAWTWindow has been created.  Fix feature AUTOMAX_PIXELSCALE so the requested pixel scale is used.

I discovered the NASA WorldWind was setting reqPixelScale immediately after GLCanvas was created.  The code in JAWTWindows ignored 'reqPixelScale' when setting up the 'hasPixelScale' value.  I surmise that AUTOMAX_PIXELSCALE was intended to all a user to set the surface scale with the GLCanvas.setSurfaceScale() call, which sets 'reqPixelScale'  These changes allow the override of using 'maxPixelScale' to set 'hasPixelScale'.

The call to GLCanvas.createJAWTDrawableAndContext() is made when the first GLCanvas.addNotify() call is made.  The JAWTWindow is created, and JAWTWindow.lockSurface() causes the DPI scaling value to be determined in JAWTWindow.updatePixelScale().