### PR TITLE
nativewindow: macOS: avoid AWT-EDT deadlock in OSXUtil.RunOnMainThread (Bug 1478)

### DIFF
--- a/src/nativewindow/classes/com/jogamp/nativewindow/awt/JAWTWindow.java
+++ b/src/nativewindow/classes/com/jogamp/nativewindow/awt/JAWTWindow.java
@@ -671,6 +671,13 @@ public abstract class JAWTWindow implements NativeWindow, OffscreenLayerSurface,
 
   @Override
   public final int lockSurface() throws NativeWindowException, RuntimeException  {
+    if( DEBUG && surfaceLock.isLockedByOtherThread() ) {
+        final Thread owner = surfaceLock.getOwner();
+        System.err.println(jawtStr2("lockSurface.wait")+" owner "+(null != owner ? owner.getName() : "null")+
+            ", queueLen "+surfaceLock.getQueueLength()+
+            ", onAWTEDT "+EventQueue.isDispatchThread());
+        ExceptionUtils.dumpStack(System.err);
+    }
     surfaceLock.lock();
     int res = surfaceLock.getHoldCount() == 1 ? LOCK_SURFACE_NOT_READY : LOCK_SUCCESS; // new lock ?
 

--- a/src/nativewindow/classes/jogamp/nativewindow/jawt/macosx/MacOSXJAWTWindow.java
+++ b/src/nativewindow/classes/jogamp/nativewindow/jawt/macosx/MacOSXJAWTWindow.java
@@ -67,13 +67,17 @@ import jogamp.nativewindow.macosx.OSXUtil;
 import jogamp.nativewindow.macosx.OSXUtil.WinAndView;
 
 public class MacOSXJAWTWindow extends JAWTWindow implements MutableSurface {
-  /** May lead to deadlock, due to AWT pos comparison .. don't enable for Applets! */
-  private static final boolean DEBUG_CALAYER_POS_CRITICAL;
+    /** May lead to deadlock, due to AWT pos comparison .. don't enable for Applets! */
+    private static final boolean DEBUG_CALAYER_POS_CRITICAL;
+    private static final boolean DEBUG_OSX_LOCK;
+    private static final boolean DEBUG_OSX_LOCK_STACK;
 
-  static {
-      Debug.initSingleton();
-      DEBUG_CALAYER_POS_CRITICAL = PropertyAccess.isPropertyDefined("nativewindow.debug.JAWT.OSXCALayerPos", true /* jnlpAlias */);
-  }
+    static {
+        Debug.initSingleton();
+        DEBUG_CALAYER_POS_CRITICAL = PropertyAccess.isPropertyDefined("nativewindow.debug.JAWT.OSXCALayerPos", true /* jnlpAlias */);
+        DEBUG_OSX_LOCK = Debug.debug("JAWT.OSXLock");
+        DEBUG_OSX_LOCK_STACK = Debug.debug("JAWT.OSXLock.Stack");
+    }
 
   public MacOSXJAWTWindow(final Object comp, final AbstractGraphicsConfiguration config) {
     super(comp, config);
@@ -241,101 +245,171 @@ public class MacOSXJAWTWindow extends JAWTWindow implements MutableSurface {
       return JAWTUtil.getJAWT(getShallUseOffscreenLayer() || isApplet());
   }
 
-  @Override
-  protected int lockSurfaceImpl(final GraphicsConfiguration gc) throws NativeWindowException {
-    int ret = NativeSurface.LOCK_SURFACE_NOT_READY;
-    ds = getJAWT().GetDrawingSurface(component);
-    if (ds == null) {
-      // Widget not yet realized
-      unlockSurfaceImpl();
-      return NativeSurface.LOCK_SURFACE_NOT_READY;
-    }
-    final int res = ds.Lock();
-    dsLocked = ( 0 == ( res & JAWTFactory.JAWT_LOCK_ERROR ) ) ;
-    if (!dsLocked) {
-      unlockSurfaceImpl();
-      throw new NativeWindowException("Unable to lock surface");
-    }
-    // See whether the surface changed and if so destroy the old
-    // OpenGL context so it will be recreated (NOTE: removeNotify
-    // should handle this case, but it may be possible that race
-    // conditions can cause this code to be triggered -- should test
-    // more)
-    if ((res & JAWTFactory.JAWT_LOCK_SURFACE_CHANGED) != 0) {
-      ret = NativeSurface.LOCK_SURFACE_CHANGED;
-    }
-    if (firstLock) {
-      SecurityUtil.doPrivileged(new PrivilegedAction<Object>() {
-          @Override
-          public Object run() {
-            dsi = ds.GetDrawingSurfaceInfo();
-            return null;
-          }
-        });
-    } else {
-      dsi = ds.GetDrawingSurfaceInfo();
-    }
-    if (dsi == null) {
-      unlockSurfaceImpl();
-      return NativeSurface.LOCK_SURFACE_NOT_READY;
-    }
-    updateLockedData(dsi.getBounds(), gc);
-    if (DEBUG && firstLock ) {
-      dumpInfo();
-    }
-    firstLock = false;
-    if( !isOffscreenLayerSurfaceEnabled() ) {
-        macosxdsi = (JAWT_MacOSXDrawingSurfaceInfo) dsi.platformInfo(getJAWT());
-        if (macosxdsi == null) {
-          unlockSurfaceImpl();
-          return NativeSurface.LOCK_SURFACE_NOT_READY;
-        }
-        drawable = macosxdsi.getCocoaViewRef();
-
-        if (drawable == 0) {
-          unlockSurfaceImpl();
-          return NativeSurface.LOCK_SURFACE_NOT_READY;
-        } else {
-          windowHandle = OSXUtil.GetNSWindow(drawable);
-          ret = NativeSurface.LOCK_SUCCESS;
-        }
-    } else {
+    @Override
+    protected int lockSurfaceImpl(final GraphicsConfiguration gc) throws NativeWindowException {
+        int ret = NativeSurface.LOCK_SURFACE_NOT_READY;
         /**
-         * Only create a fake invisible NSWindow for the drawable handle
-         * to please frameworks requiring such (eg. NEWT).
-         *
-         * The actual surface/ca-layer shall be created/attached
-         * by the upper framework (JOGL) since they require more information.
+         * Offscreen-layer (JAWT CALayer) path: Create an invisible dummy NSWindow/NSView pair once.
+         * <p>
+         * NEWT (and other upper layers) require a non-zero NSView handle as the {@code drawable} handle,
+         * even though actual rendering is done via the JAWT offscreen-layer / CALayer.
+         * </p>
+         * <p>
+         * This operation must run on the AppKit main thread and may be executed while the AWT EDT
+         * is in the middle of peer realization / layout. On macOS 13+ this can lead to a deadlock
+         * between AWT EDT and NEWT EDT if we keep {@link JAWTWindow}'s surface lock and the
+         * {@link com.jogamp.nativewindow.AbstractGraphicsDevice} lock held while synchronously waiting:
+         * the AWT nested event loop (used to avoid freezing the EDT, see Bug 1478) can re-enter NEWT
+         * parenting code, while NEWT simultaneously tries to lock the same surface.
+         * </p>
+         * <p>
+         * To avoid this lock inversion, temporarily drop both locks <em>before</em> touching the JAWT
+         * {@link JAWT_DrawingSurface}, perform the main-thread work, then reacquire the locks and continue.
+         * </p>
          */
-        String errMsg = null;
-        if(0 == drawable) {
-            final WinAndView wv = OSXUtil.CreateNSWindow2(0, 0, 64, 64);
-            windowHandle = wv.win;
-            if(0 == windowHandle) {
-              errMsg = "Unable to create dummy NSWindow (layered case)";
-            } else {
-                drawable = wv.view;
-                if(0 == drawable) {
-                  errMsg = "Null NSView of NSWindow "+toHexString(windowHandle);
+        if( isOffscreenLayerSurfaceEnabled() && 0 == drawable ) {
+            final com.jogamp.nativewindow.AbstractGraphicsDevice adevice = getGraphicsConfiguration().getScreen().getDevice();
+            final com.jogamp.common.util.locks.RecursiveLock surfaceLock = getLock();
+            final WinAndView wv;
+
+            if( DEBUG_OSX_LOCK ) {
+                System.err.println("MacOSXJAWTWindow.lockSurfaceImpl: create dummy NSWindow/NSView start, thread "+Thread.currentThread().getName()+
+                        ", drawable 0x"+Long.toHexString(drawable)+", windowHandle 0x"+Long.toHexString(windowHandle)+
+                        ", surfaceLock[hold "+surfaceLock.getHoldCount()+", qlen "+surfaceLock.getQueueLength()+", owner "+surfaceLock.getOwner()+"]"+
+                        ", adevice "+adevice);
+                if( DEBUG_OSX_LOCK_STACK ) {
+                    com.jogamp.common.ExceptionUtils.dumpStack(System.err);
                 }
             }
-            if(null == errMsg) {
+
+            // Drop locks in reverse acquisition order (device -> surface) and reacquire (surface -> device).
+            adevice.unlock();
+            surfaceLock.unlock();
+            try {
+                if( DEBUG_OSX_LOCK ) {
+                    System.err.println("MacOSXJAWTWindow.lockSurfaceImpl: create dummy NSWindow/NSView - dropped locks, calling OSXUtil.CreateNSWindow2(..)");
+                }
+                wv = OSXUtil.CreateNSWindow2(0, 0, 64, 64);
+            } finally {
+                surfaceLock.lock();
+                adevice.lock();
+            }
+
+            if( DEBUG_OSX_LOCK ) {
+                System.err.println("MacOSXJAWTWindow.lockSurfaceImpl: create dummy NSWindow/NSView - reacquired locks, got win 0x"+Long.toHexString(wv.win)+
+                        ", view 0x"+Long.toHexString(wv.view)+", thread "+Thread.currentThread().getName()+
+                        ", surfaceLock[hold "+surfaceLock.getHoldCount()+", qlen "+surfaceLock.getQueueLength()+", owner "+surfaceLock.getOwner()+"]");
+            }
+
+            // Another thread may have initialized while the locks were dropped.
+            if( 0 == drawable ) {
+                windowHandle = wv.win;
+                if(0 == windowHandle) {
+                    throw new NativeWindowException("Unable to create dummy NSWindow (layered case): "+this);
+                }
+                drawable = wv.view;
+                if(0 == drawable) {
+                    throw new NativeWindowException("Null NSView of NSWindow "+toHexString(windowHandle)+": "+this);
+                }
+
+                if( DEBUG_OSX_LOCK ) {
+                    System.err.println("MacOSXJAWTWindow.lockSurfaceImpl: installed dummy NSWindow/NSView win 0x"+Long.toHexString(windowHandle)+
+                            ", view 0x"+Long.toHexString(drawable)+", thread "+Thread.currentThread().getName());
+                }
+
                 // Fix caps reflecting offscreen! (no GL available here ..)
                 final Capabilities caps = (Capabilities) getGraphicsConfiguration().getChosenCapabilities().cloneMutable();
                 caps.setOnscreen(false);
                 setChosenCapabilities(caps);
+            } else if( 0 != wv.win ) {
+                // Cleanup: We created a dummy NSWindow, but another thread won the race and installed its own.
+                // Destroy the now-unreferenced window on the AppKit main thread.
+                final long createdWin = wv.win;
+                if( DEBUG_OSX_LOCK ) {
+                    System.err.println("MacOSXJAWTWindow.lockSurfaceImpl: discarding extra dummy NSWindow 0x"+Long.toHexString(createdWin)+
+                            ", thread "+Thread.currentThread().getName());
+                }
+                OSXUtil.RunOnMainThread(false /* wait */, false /* kickNSApp */, new Runnable() {
+                    @Override
+                    public void run() {
+                        OSXUtil.DestroyNSWindow(createdWin);
+                    } } );
             }
         }
-        if(null == errMsg) {
-            jawtSurfaceLayersHandle = GetJAWTSurfaceLayersHandle0(dsi.getBuffer());
-            OSXUtil.RunOnMainThread(false /* wait */, false, new Runnable() {
+        ds = getJAWT().GetDrawingSurface(component);
+        if (ds == null) {
+            // Widget not yet realized
+            unlockSurfaceImpl();
+            return NativeSurface.LOCK_SURFACE_NOT_READY;
+        }
+        final int res = ds.Lock();
+        dsLocked = ( 0 == ( res & JAWTFactory.JAWT_LOCK_ERROR ) ) ;
+        if (!dsLocked) {
+            unlockSurfaceImpl();
+            throw new NativeWindowException("Unable to lock surface");
+        }
+        // See whether the surface changed and if so destroy the old
+        // OpenGL context so it will be recreated (NOTE: removeNotify
+        // should handle this case, but it may be possible that race
+        // conditions can cause this code to be triggered -- should test
+        // more)
+        if ((res & JAWTFactory.JAWT_LOCK_SURFACE_CHANGED) != 0) {
+            ret = NativeSurface.LOCK_SURFACE_CHANGED;
+        }
+        if (firstLock) {
+            SecurityUtil.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    dsi = ds.GetDrawingSurfaceInfo();
+                    return null;
+                }
+            });
+        } else {
+            dsi = ds.GetDrawingSurfaceInfo();
+        }
+        if (dsi == null) {
+            unlockSurfaceImpl();
+            return NativeSurface.LOCK_SURFACE_NOT_READY;
+        }
+        updateLockedData(dsi.getBounds(), gc);
+        if (DEBUG && firstLock ) {
+            dumpInfo();
+        }
+        firstLock = false;
+        if( !isOffscreenLayerSurfaceEnabled() ) {
+            macosxdsi = (JAWT_MacOSXDrawingSurfaceInfo) dsi.platformInfo(getJAWT());
+            if (macosxdsi == null) {
+                unlockSurfaceImpl();
+                return NativeSurface.LOCK_SURFACE_NOT_READY;
+            }
+            drawable = macosxdsi.getCocoaViewRef();
+
+            if (drawable == 0) {
+                unlockSurfaceImpl();
+                return NativeSurface.LOCK_SURFACE_NOT_READY;
+            } else {
+                windowHandle = OSXUtil.GetNSWindow(drawable);
+                ret = NativeSurface.LOCK_SUCCESS;
+            }
+        } else {
+            /**
+             * Only create a fake invisible NSWindow for the drawable handle
+             * to please frameworks requiring such (eg. NEWT).
+             *
+             * The actual surface/ca-layer shall be created/attached
+             * by the upper framework (JOGL) since they require more information.
+             */
+            String errMsg = null;
+            if(null == errMsg) {
+                jawtSurfaceLayersHandle = GetJAWTSurfaceLayersHandle0(dsi.getBuffer());
+                OSXUtil.RunOnMainThread(false /* wait */, false, new Runnable() {
                     @Override
                     public void run() {
                         String errMsg = null;
                         if(0 == rootSurfaceLayer && 0 != jawtSurfaceLayersHandle) {
                             rootSurfaceLayer = OSXUtil.CreateCALayer(jawt_surface_bounds.getWidth(), jawt_surface_bounds.getHeight(), getPixelScaleX()); // HiDPI: uniform pixel scale
                             if(0 == rootSurfaceLayer) {
-                              errMsg = "Could not create root CALayer";
+                                errMsg = "Could not create root CALayer";
                             } else {
                                 try {
                                     SetJAWTRootSurfaceLayer0(jawtSurfaceLayersHandle, rootSurfaceLayer);

--- a/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
+++ b/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
@@ -32,8 +32,10 @@ import com.jogamp.nativewindow.NativeWindowFactory;
 import com.jogamp.nativewindow.util.Insets;
 import com.jogamp.nativewindow.util.Point;
 
+import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.jogamp.common.ExceptionUtils;
 import com.jogamp.common.os.NativeLibrary;
@@ -53,6 +55,138 @@ public class OSXUtil implements ToolkitProperties {
 
     private static final ThreadLocal<Boolean> tlsIsMainThread = new ThreadLocal<Boolean>();
 
+    /**
+     * Optional AWT/EDT helpers used to avoid macOS AppKit &amp; AWT-EDT deadlocks when synchronously
+     * executing tasks on the AppKit main thread.
+     * <p>
+     * {@code nativewindow} can be used without AWT (and even without the {@code java.desktop} module)
+     * in some configurations, hence these AWT classes are resolved via reflection and are additionally
+     * guarded by {@link NativeWindowFactory#isAWTAvailable()}.
+     * </p>
+     * <p>
+     * Rationale (Bug 1478): On macOS 13/14, calling {@link #RunOnMainThread(boolean, boolean, Runnable)}
+     * with {@code waitUntilDone=true} from the AWT Event Dispatch Thread (EDT) can deadlock if the
+     * AppKit-side work needs the EDT to keep pumping events (e.g. during peer/window realization).
+     * Using {@code java.awt.SecondaryLoop} keeps the EDT dispatching while still providing
+     * synchronous semantics.
+     * </p>
+     */
+    private static final class AWTEDTUtil {
+        private static final boolean available;
+        private static final Method eventQueueIsDispatchThread;
+        private static final Method toolkitGetDefaultToolkit;
+        private static final Method toolkitGetSystemEventQueue;
+        private static final Method eventQueueCreateSecondaryLoop;
+        private static final Method secondaryLoopEnter;
+        private static final Method secondaryLoopExit;
+
+        static {
+            boolean ok = false;
+            Method mIsDispatchThread = null;
+            Method mGetDefaultToolkit = null;
+            Method mGetSystemEventQueue = null;
+            Method mCreateSecondaryLoop = null;
+            Method mEnter = null;
+            Method mExit = null;
+
+            try {
+                final ClassLoader cl = OSXUtil.class.getClassLoader();
+                final Class<?> eventQueueClass = Class.forName("java.awt.EventQueue", false, cl);
+                final Class<?> toolkitClass = Class.forName("java.awt.Toolkit", false, cl);
+                final Class<?> secondaryLoopClass = Class.forName("java.awt.SecondaryLoop", false, cl);
+
+                mIsDispatchThread = eventQueueClass.getMethod("isDispatchThread");
+                mGetDefaultToolkit = toolkitClass.getMethod("getDefaultToolkit");
+                mGetSystemEventQueue = toolkitClass.getMethod("getSystemEventQueue");
+                mCreateSecondaryLoop = eventQueueClass.getMethod("createSecondaryLoop");
+                mEnter = secondaryLoopClass.getMethod("enter");
+                mExit = secondaryLoopClass.getMethod("exit");
+
+                ok = true;
+            } catch (final Throwable t) {
+                ok = false;
+            }
+
+            available = ok;
+            eventQueueIsDispatchThread = mIsDispatchThread;
+            toolkitGetDefaultToolkit = mGetDefaultToolkit;
+            toolkitGetSystemEventQueue = mGetSystemEventQueue;
+            eventQueueCreateSecondaryLoop = mCreateSecondaryLoop;
+            secondaryLoopEnter = mEnter;
+            secondaryLoopExit = mExit;
+        }
+
+        /**
+         * @return {@code true} if the current thread is the AWT EDT, otherwise {@code false}.
+         */
+        private static boolean isDispatchThread() {
+            if( !available || !NativeWindowFactory.isAWTAvailable() ) {
+                return false;
+            }
+            try {
+                return ((Boolean) eventQueueIsDispatchThread.invoke(null)).booleanValue();
+            } catch (final Throwable t) {
+                return false;
+            }
+        }
+
+        /**
+         * Creates an AWT {@code SecondaryLoop} for the current {@code EventQueue}.
+         * <p>
+         * When entered on the EDT, the secondary loop keeps dispatching AWT events, allowing re-entrant
+         * operations that would otherwise deadlock if the EDT was blocked in {@code Object.wait()}.
+         * </p>
+         *
+         * @return the secondary loop instance, or {@code null} if unavailable.
+         */
+        private static Object createSecondaryLoop() {
+            if( !available || !NativeWindowFactory.isAWTAvailable() ) {
+                return null;
+            }
+            try {
+                final Object toolkit = toolkitGetDefaultToolkit.invoke(null);
+                final Object eventQueue = toolkitGetSystemEventQueue.invoke(toolkit);
+                return eventQueueCreateSecondaryLoop.invoke(eventQueue);
+            } catch (final Throwable t) {
+                return null;
+            }
+        }
+
+        /**
+         * Enters the given AWT {@code SecondaryLoop}.
+         *
+         * @param loop secondary loop instance, may be {@code null}.
+         * @return {@code true} if entered, otherwise {@code false}.
+         */
+        private static boolean enterSecondaryLoop(final Object loop) {
+            if( null == loop ) {
+                return false;
+            }
+            try {
+                return ((Boolean) secondaryLoopEnter.invoke(loop)).booleanValue();
+            } catch (final Throwable t) {
+                return false;
+            }
+        }
+
+        /**
+         * Exits the given AWT {@code SecondaryLoop}.
+         * <p>
+         * Safe to call even if the loop is already exiting.
+         * </p>
+         *
+         * @param loop secondary loop instance, may be {@code null}.
+         */
+        private static void exitSecondaryLoop(final Object loop) {
+            if( null == loop ) {
+                return;
+            }
+            try {
+                secondaryLoopExit.invoke(loop);
+            } catch (final Throwable t) { /* ignore */ }
+        }
+    }
+
     /** FIXME HiDPI: OSX unique and maximum value {@value} */
     public static final int MAX_PIXELSCALE = 2;
 
@@ -61,33 +195,33 @@ public class OSXUtil implements ToolkitProperties {
      * @see ToolkitProperties
      */
     public static synchronized void initSingleton() {
-      if(!isInit) {
-          final boolean useMainThreadChecker = Debug.debug("OSXUtil.MainThreadChecker");
-          if(DEBUG || useMainThreadChecker) {
-              System.out.println("OSXUtil.initSingleton() - useMainThreadChecker "+useMainThreadChecker);
-          }
-          if(!NWJNILibLoader.loadNativeWindow("macosx")) {
-              throw new NativeWindowException("NativeWindow MacOSX native library load error.");
-          }
-          if( useMainThreadChecker ) {
-              final String libMainThreadChecker = "/Applications/Xcode.app/Contents/Developer/usr/lib/libMainThreadChecker.dylib";
-              final NativeLibrary lib = SecurityUtil.doPrivileged(new PrivilegedAction<NativeLibrary>() {
-                  @Override
-                  public NativeLibrary run() {
-                      return NativeLibrary.open(libMainThreadChecker, false, false, OSXUtil.class.getClassLoader(), true);
-                  } } );
-              if( null == lib ) {
-                  System.err.println("Could not load "+libMainThreadChecker);
-              } else {
-                  System.err.println("Loaded "+lib);
-              }
-          }
+        if(!isInit) {
+            final boolean useMainThreadChecker = Debug.debug("OSXUtil.MainThreadChecker");
+            if(DEBUG || useMainThreadChecker) {
+                System.out.println("OSXUtil.initSingleton() - useMainThreadChecker "+useMainThreadChecker);
+            }
+            if(!NWJNILibLoader.loadNativeWindow("macosx")) {
+                throw new NativeWindowException("NativeWindow MacOSX native library load error.");
+            }
+            if( useMainThreadChecker ) {
+                final String libMainThreadChecker = "/Applications/Xcode.app/Contents/Developer/usr/lib/libMainThreadChecker.dylib";
+                final NativeLibrary lib = SecurityUtil.doPrivileged(new PrivilegedAction<NativeLibrary>() {
+                    @Override
+                    public NativeLibrary run() {
+                        return NativeLibrary.open(libMainThreadChecker, false, false, OSXUtil.class.getClassLoader(), true);
+                    } } );
+                if( null == lib ) {
+                    System.err.println("Could not load "+libMainThreadChecker);
+                } else {
+                    System.err.println("Loaded "+lib);
+                }
+            }
 
-          if( !initIDs0() ) {
-              throw new NativeWindowException("MacOSX: Could not initialized native stub");
-          }
-          isInit = true;
-      }
+            if( !initIDs0() ) {
+                throw new NativeWindowException("MacOSX: Could not initialized native stub");
+            }
+            isInit = true;
+        }
     }
 
     /**
@@ -123,43 +257,43 @@ public class OSXUtil implements ToolkitProperties {
      * @return top-left client-area position in window units
      */
     public static Point GetLocationOnScreen(final long windowOrView, final int src_x, final int src_y) {
-      return (Point) GetLocationOnScreen0(windowOrView, src_x, src_y);
+        return (Point) GetLocationOnScreen0(windowOrView, src_x, src_y);
     }
 
     public static Insets GetInsets(final long windowOrView) {
-      return (Insets) GetInsets0(windowOrView);
+        return (Insets) GetInsets0(windowOrView);
     }
 
     public static float GetScreenPixelScaleByDisplayID(final int displayID) {
-      if( 0 != displayID ) {
-          return GetScreenPixelScale1(displayID);
-      } else {
-          return 1.0f; // default
-      }
+        if( 0 != displayID ) {
+            return GetScreenPixelScale1(displayID);
+        } else {
+            return 1.0f; // default
+        }
     }
     public static float GetScreenPixelScale(final long windowOrView) {
-      if( 0 != windowOrView ) {
-          return GetScreenPixelScale2(windowOrView);
-      } else {
-          return 1.0f; // default
-      }
+        if( 0 != windowOrView ) {
+            return GetScreenPixelScale2(windowOrView);
+        } else {
+            return 1.0f; // default
+        }
     }
     public static float GetWindowPixelScale(final long windowOrView) {
-      if( 0 != windowOrView ) {
-          return GetWindowPixelScale1(windowOrView);
-      } else {
-          return 1.0f; // default
-      }
+        if( 0 != windowOrView ) {
+            return GetWindowPixelScale1(windowOrView);
+        } else {
+            return 1.0f; // default
+        }
     }
     public static void SetWindowPixelScale(final long windowOrView, final float reqPixelScale) {
-      if( 0 != windowOrView ) {
-          SetWindowPixelScale1(windowOrView, reqPixelScale);
-      }
+        if( 0 != windowOrView ) {
+            SetWindowPixelScale1(windowOrView, reqPixelScale);
+        }
     }
 
     /** Creates an NSWindow on the main-thread */
     public static long CreateNSWindow(final int x, final int y, final int width, final int height) {
-      return RunOnMainThreadLong(false /* kickNSApp */, () -> { return CreateNSWindow0(x, y, width, height); });
+        return RunOnMainThreadLong(false /* kickNSApp */, () -> { return CreateNSWindow0(x, y, width, height); });
     }
     public static class WinAndView {
         public final long win;
@@ -168,31 +302,31 @@ public class OSXUtil implements ToolkitProperties {
     }
     /** Creates an NSWindow and retrieves its NSView on the main-thread */
     public static WinAndView CreateNSWindow2(final int x, final int y, final int width, final int height) {
-            final AtomicLong nsWin0 = new AtomicLong(0);
-            final AtomicLong nsView0 = new AtomicLong(0);
+        final AtomicLong nsWin0 = new AtomicLong(0);
+        final AtomicLong nsView0 = new AtomicLong(0);
 
-            OSXUtil.RunOnMainThread(true, false /* kickNSApp */, () -> {
-                final long w = OSXUtil.CreateNSWindow0(0, 0, 64, 64);
-                if( 0 != w ) {
-                    nsWin0.set( w );
-                    nsView0.set( OSXUtil.GetNSView0(w) );
-                }
-            });
-            return new WinAndView(nsWin0.get(), nsView0.get());
+        OSXUtil.RunOnMainThread(true, false /* kickNSApp */, () -> {
+            final long w = OSXUtil.CreateNSWindow0(0, 0, 64, 64);
+            if( 0 != w ) {
+                nsWin0.set( w );
+                nsView0.set( OSXUtil.GetNSView0(w) );
+            }
+        });
+        return new WinAndView(nsWin0.get(), nsView0.get());
     }
 
     public static void DestroyNSWindow(final long nsWindow) {
-      DestroyNSWindow0(nsWindow);
+        DestroyNSWindow0(nsWindow);
     }
     public static long GetNSView(final long nsWindow, final boolean onMainThread) {
-      if( onMainThread ) {
-          return RunOnMainThreadLong(false /* kickNSApp */, () -> { return GetNSView0(nsWindow); });
-      } else {
-          return GetNSView0(nsWindow);
-      }
+        if( onMainThread ) {
+            return RunOnMainThreadLong(false /* kickNSApp */, () -> { return GetNSView0(nsWindow); });
+        } else {
+            return GetNSView0(nsWindow);
+        }
     }
     public static long GetNSWindow(final long nsView) {
-      return GetNSWindow0(nsView);
+        return GetNSWindow0(nsView);
     }
 
     /**
@@ -205,11 +339,11 @@ public class OSXUtil implements ToolkitProperties {
      * @see #AddCASublayer(long, long)
      */
     public static long CreateCALayer(final int width, final int height, final float contentsScale) {
-      final long l = CreateCALayer0(width, height, contentsScale);
-      if(DEBUG) {
-          System.err.println("OSXUtil.CreateCALayer: 0x"+Long.toHexString(l)+" - "+Thread.currentThread().getName());
-      }
-      return l;
+        final long l = CreateCALayer0(width, height, contentsScale);
+        if(DEBUG) {
+            System.err.println("OSXUtil.CreateCALayer: 0x"+Long.toHexString(l)+" - "+Thread.currentThread().getName());
+        }
+        return l;
     }
 
     /**
@@ -326,6 +460,36 @@ public class OSXUtil implements ToolkitProperties {
         if( IsMainThread() ) {
             runnable.run(); // don't leave the JVM
         } else {
+            if( waitUntilDone && AWTEDTUtil.isDispatchThread() ) {
+                // Bug 1478: Avoid blocking the AWT EDT in Object.wait() while synchronously waiting for the
+                // AppKit main-thread runnable. The AppKit-side work (e.g. NSWindow/NSView creation used by the
+                // CALayer/JAWT path) can require AWT events to be processed during window/peer realization.
+                // Using an AWT SecondaryLoop keeps the EDT dispatching while we wait for completion.
+                final Object secondaryLoop = AWTEDTUtil.createSecondaryLoop();
+                if( null != secondaryLoop ) {
+                    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+                    final Runnable runnable0 = new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                runnable.run();
+                            } catch (final Throwable t) {
+                                throwableRef.set(t);
+                            } finally {
+                                // Ensure the EDT leaves the nested event loop even if the runnable fails.
+                                AWTEDTUtil.exitSecondaryLoop(secondaryLoop);
+                            }
+                        }
+                    };
+                    RunOnMainThread0(kickNSApp, runnable0);
+                    AWTEDTUtil.enterSecondaryLoop(secondaryLoop);
+                    final Throwable throwable = throwableRef.get();
+                    if( null != throwable ) {
+                        throw new RuntimeException(throwable);
+                    }
+                    return;
+                }
+            }
             // Utilize Java side lock/wait and simply pass the Runnable async to OSX main thread,
             // otherwise we may freeze the OSX main thread.
             final Object sync = new Object();
@@ -355,6 +519,34 @@ public class OSXUtil implements ToolkitProperties {
         if( IsMainThread() ) {
             return task.eval(); // don't leave the JVM
         } else {
+            if( AWTEDTUtil.isDispatchThread() ) {
+                // See RunOnMainThread(..): keep the AWT EDT responsive while synchronously waiting for AppKit.
+                final Object secondaryLoop = AWTEDTUtil.createSecondaryLoop();
+                if( null != secondaryLoop ) {
+                    final AtomicLong result = new AtomicLong(0);
+                    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+                    final Runnable runnable = new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                result.set(task.eval());
+                            } catch (final Throwable t) {
+                                throwableRef.set(t);
+                            } finally {
+                                // Ensure the EDT leaves the nested event loop even if the runnable fails.
+                                AWTEDTUtil.exitSecondaryLoop(secondaryLoop);
+                            }
+                        }
+                    };
+                    RunOnMainThread0(kickNSApp, runnable);
+                    AWTEDTUtil.enterSecondaryLoop(secondaryLoop);
+                    final Throwable throwable = throwableRef.get();
+                    if( null != throwable ) {
+                        throw new RuntimeException(throwable);
+                    }
+                    return result.get();
+                }
+            }
             // Utilize Java side lock/wait and simply pass the Runnable async to OSX main thread,
             // otherwise we may freeze the OSX main thread.
             final Object sync = new Object();
@@ -428,6 +620,34 @@ public class OSXUtil implements ToolkitProperties {
         if( IsMainThread() ) {
             return func.eval(args); // don't leave the JVM
         } else {
+            if( AWTEDTUtil.isDispatchThread() ) {
+                // See RunOnMainThread(..): keep the AWT EDT responsive while synchronously waiting for AppKit.
+                final Object secondaryLoop = AWTEDTUtil.createSecondaryLoop();
+                if( null != secondaryLoop ) {
+                    final AtomicReference<R> result = new AtomicReference<R>();
+                    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+                    final Runnable runnable = new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                result.set(func.eval(args));
+                            } catch (final Throwable t) {
+                                throwableRef.set(t);
+                            } finally {
+                                // Ensure the EDT leaves the nested event loop even if the runnable fails.
+                                AWTEDTUtil.exitSecondaryLoop(secondaryLoop);
+                            }
+                        }
+                    };
+                    RunOnMainThread0(kickNSApp, runnable);
+                    AWTEDTUtil.enterSecondaryLoop(secondaryLoop);
+                    final Throwable throwable = throwableRef.get();
+                    if( null != throwable ) {
+                        throw new RuntimeException(throwable);
+                    }
+                    return result.get();
+                }
+            }
             // Utilize Java side lock/wait and simply pass the Runnable async to OSX main thread,
             // otherwise we may freeze the OSX main thread.
             final Object sync = new Object();

--- a/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
+++ b/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
@@ -52,6 +52,9 @@ import jogamp.nativewindow.ToolkitProperties;
 public class OSXUtil implements ToolkitProperties {
     private static boolean isInit = false;
     private static final boolean DEBUG = Debug.debug("OSXUtil");
+    private static final boolean DEBUG_RUNONMAIN = Debug.debug("OSXUtil.RunOnMainThread");
+    private static final boolean DEBUG_RUNONMAIN_STACK = Debug.debug("OSXUtil.RunOnMainThread.Stack");
+    private static final boolean DEBUG_AWTEDTUTIL = Debug.debug("OSXUtil.AWTEDTUtil");
 
     private static final ThreadLocal<Boolean> tlsIsMainThread = new ThreadLocal<Boolean>();
 
@@ -114,6 +117,14 @@ public class OSXUtil implements ToolkitProperties {
             eventQueueCreateSecondaryLoop = mCreateSecondaryLoop;
             secondaryLoopEnter = mEnter;
             secondaryLoopExit = mExit;
+
+            if( DEBUG_AWTEDTUTIL ) {
+                System.err.println("OSXUtil.AWTEDTUtil: available "+available+
+                        ", awtAvailable "+NativeWindowFactory.isAWTAvailable()+
+                        ", EventQueue.isDispatchThread "+(null != eventQueueIsDispatchThread)+
+                        ", EventQueue.createSecondaryLoop "+(null != eventQueueCreateSecondaryLoop)+
+                        ", SecondaryLoop.enter/exit "+(null != secondaryLoopEnter)+"/"+(null != secondaryLoopExit));
+            }
         }
 
         /**
@@ -305,13 +316,34 @@ public class OSXUtil implements ToolkitProperties {
         final AtomicLong nsWin0 = new AtomicLong(0);
         final AtomicLong nsView0 = new AtomicLong(0);
 
-        OSXUtil.RunOnMainThread(true, false /* kickNSApp */, () -> {
-            final long w = OSXUtil.CreateNSWindow0(0, 0, 64, 64);
+        if( DEBUG_RUNONMAIN ) {
+            System.err.println("OSXUtil.CreateNSWindow2: enter x/y "+x+"/"+y+", size "+width+"x"+height+
+                    ", onMain "+IsMainThread()+", onAWTEDT "+AWTEDTUtil.isDispatchThread()+
+                    ", thread "+Thread.currentThread().getName());
+            if( DEBUG_RUNONMAIN_STACK ) {
+                ExceptionUtils.dumpStack(System.err);
+            }
+        }
+
+        // Waking NSApp helps ensuring the runnable gets processed promptly on the AppKit main thread
+        // (important when invoked while AWT is in the middle of realization/layout).
+        OSXUtil.RunOnMainThread(true, true /* kickNSApp */, () -> {
+            final long w = OSXUtil.CreateNSWindow0(x, y, width, height);
             if( 0 != w ) {
                 nsWin0.set( w );
                 nsView0.set( OSXUtil.GetNSView0(w) );
             }
+            if( DEBUG_RUNONMAIN ) {
+                System.err.println("OSXUtil.CreateNSWindow2: appkit created win 0x"+Long.toHexString(w)+
+                        ", view 0x"+Long.toHexString(nsView0.get())+
+                        ", thread "+Thread.currentThread().getName());
+            }
         });
+        if( DEBUG_RUNONMAIN ) {
+            System.err.println("OSXUtil.CreateNSWindow2: exit win 0x"+Long.toHexString(nsWin0.get())+
+                    ", view 0x"+Long.toHexString(nsView0.get())+
+                    ", thread "+Thread.currentThread().getName());
+        }
         return new WinAndView(nsWin0.get(), nsView0.get());
     }
 
@@ -457,8 +489,24 @@ public class OSXUtil implements ToolkitProperties {
      * @param runnable
      */
     public static void RunOnMainThread(final boolean waitUntilDone, final boolean kickNSApp, final Runnable runnable) {
+        final long t0;
+        if( DEBUG_RUNONMAIN ) {
+            t0 = System.currentTimeMillis();
+            System.err.println("OSXUtil.RunOnMainThread: enter wait "+waitUntilDone+", kickNSApp "+kickNSApp+
+                    ", onMain "+IsMainThread()+", onAWTEDT "+AWTEDTUtil.isDispatchThread()+
+                    ", thread "+Thread.currentThread().getName());
+            if( DEBUG_RUNONMAIN_STACK ) {
+                ExceptionUtils.dumpStack(System.err);
+            }
+        } else {
+            t0 = 0;
+        }
         if( IsMainThread() ) {
             runnable.run(); // don't leave the JVM
+            if( DEBUG_RUNONMAIN ) {
+                final long dt = System.currentTimeMillis() - t0;
+                System.err.println("OSXUtil.RunOnMainThread: exit (onMain) dt "+dt+" ms, thread "+Thread.currentThread().getName());
+            }
         } else {
             if( waitUntilDone && AWTEDTUtil.isDispatchThread() ) {
                 // Bug 1478: Avoid blocking the AWT EDT in Object.wait() while synchronously waiting for the
@@ -472,20 +520,33 @@ public class OSXUtil implements ToolkitProperties {
                         @Override
                         public void run() {
                             try {
+                                if( DEBUG_RUNONMAIN ) {
+                                    System.err.println("OSXUtil.RunOnMainThread: appkit-runner start, thread "+Thread.currentThread().getName());
+                                }
                                 runnable.run();
                             } catch (final Throwable t) {
                                 throwableRef.set(t);
                             } finally {
                                 // Ensure the EDT leaves the nested event loop even if the runnable fails.
+                                if( DEBUG_RUNONMAIN ) {
+                                    System.err.println("OSXUtil.RunOnMainThread: appkit-runner done, thread "+Thread.currentThread().getName());
+                                }
                                 AWTEDTUtil.exitSecondaryLoop(secondaryLoop);
                             }
                         }
                     };
+                    if( DEBUG_RUNONMAIN ) {
+                        System.err.println("OSXUtil.RunOnMainThread: using AWT SecondaryLoop");
+                    }
                     RunOnMainThread0(kickNSApp, runnable0);
                     AWTEDTUtil.enterSecondaryLoop(secondaryLoop);
                     final Throwable throwable = throwableRef.get();
                     if( null != throwable ) {
                         throw new RuntimeException(throwable);
+                    }
+                    if( DEBUG_RUNONMAIN ) {
+                        final long dt = System.currentTimeMillis() - t0;
+                        System.err.println("OSXUtil.RunOnMainThread: exit (SecondaryLoop) dt "+dt+" ms, thread "+Thread.currentThread().getName());
                     }
                     return;
                 }
@@ -495,6 +556,9 @@ public class OSXUtil implements ToolkitProperties {
             final Object sync = new Object();
             final RunnableTask rt = new RunnableTask( runnable, waitUntilDone ? sync : null, true, waitUntilDone ? null : System.err );
             synchronized(sync) {
+                if( DEBUG_RUNONMAIN ) {
+                    System.err.println("OSXUtil.RunOnMainThread: using sync-wait, thread "+Thread.currentThread().getName());
+                }
                 RunOnMainThread0(kickNSApp, rt);
                 if( waitUntilDone ) {
                     while( rt.isInQueue() ) {
@@ -509,6 +573,11 @@ public class OSXUtil implements ToolkitProperties {
                         }
                     }
                 }
+            }
+            if( DEBUG_RUNONMAIN ) {
+                final long dt = System.currentTimeMillis() - t0;
+                System.err.println("OSXUtil.RunOnMainThread: exit (sync-wait) dt "+dt+" ms, wait "+waitUntilDone+
+                        ", kickNSApp "+kickNSApp+", thread "+Thread.currentThread().getName());
             }
         }
     }

--- a/src/newt/classes/com/jogamp/newt/awt/NewtCanvasAWT.java
+++ b/src/newt/classes/com/jogamp/newt/awt/NewtCanvasAWT.java
@@ -37,11 +37,14 @@ import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.KeyboardFocusManager;
+import java.awt.SecondaryLoop;
+import java.awt.Toolkit;
 import java.awt.geom.NoninvertibleTransformException;
 import java.beans.Beans;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.jogamp.nativewindow.CapabilitiesImmutable;
 import com.jogamp.nativewindow.NativeSurface;
@@ -638,8 +641,8 @@ public class NewtCanvasAWT extends java.awt.Canvas implements NativeWindowHolder
                     // if ( isShowing() == false ) -> Container was not visible yet.
                     // if ( isShowing() == true  ) -> Container is already visible.
                     System.err.println("NewtCanvasAWT.addNotify.X: twin "+newtWinHandleToHexString(newtChild)+
-                                       ", comp "+this+", visible "+isVisible()+", showing "+isShowing()+
-                                       ", displayable "+isDisplayable()+", cont "+AWTMisc.getContainer(this));
+                            ", comp "+this+", visible "+isVisible()+", showing "+isShowing()+
+                            ", displayable "+isDisplayable()+", cont "+AWTMisc.getContainer(this));
                 }
             }
         }
@@ -1034,6 +1037,82 @@ public class NewtCanvasAWT extends java.awt.Canvas implements NativeWindowHolder
         return !isOnscreen;
     }
 
+    /**
+     * Runs {@code task} on NEWT's EDT while keeping the AWT EDT responsive.
+     * <p>
+     * On macOS (esp. 13+), synchronous cross-toolkit operations can deadlock when the AWT EDT waits
+     * for the NEWT EDT while NEWT (or AppKit) requires the AWT EDT to keep pumping events.
+     * </p>
+     * <p>
+     * When running on the AWT EDT on macOS, this helper uses an AWT {@link SecondaryLoop} to keep
+     * dispatching AWT events while waiting for the NEWT task to complete.
+     * This is primarily required for the macOS offscreen-layer / CALayer path and early peer
+     * realization, but is applied unconditionally on macOS to avoid order-dependent deadlocks.
+     * </p>
+     */
+    private final void runOnNewtEDTAndWaitOnAWTEDT(final Runnable task, final String dbgTag) {
+        // Only needed on macOS, where AppKit integration can require nested AWT event processing
+        // during peer realization / reparenting (see Bug 1478).
+        //
+        // Note: We intentionally do not gate this on JAWTWindow.isOffscreenLayerSurfaceEnabled(),
+        // since the flag is only valid after the first successful JAWT surface lock. On macOS,
+        // the problematic AWT/NEWT reparent sequence can occur before that point (e.g. during the
+        // first attach while the AWT peer is being realized).
+        if( EventQueue.isDispatchThread() &&
+                Platform.OSType.MACOS == Platform.getOSType() &&
+                null != jawtWindow ) {
+
+            final SecondaryLoop loop = Toolkit.getDefaultToolkit().getSystemEventQueue().createSecondaryLoop();
+            if( null == loop ) {
+                // Fallback: should not happen on supported JDKs, but keep existing behavior.
+                task.run();
+                return;
+            }
+
+            final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+            final Runnable task0 = new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if( DEBUG ) {
+                            System.err.println("NewtCanvasAWT."+dbgTag+".newtTask.0 @ "+currentThreadName());
+                        }
+                        task.run();
+                    } catch (final Throwable t) {
+                        throwableRef.set(t);
+                    } finally {
+                        if( DEBUG ) {
+                            System.err.println("NewtCanvasAWT."+dbgTag+".newtTask.X @ "+currentThreadName());
+                        }
+                        loop.exit();
+                    }
+                }
+            };
+
+            if( DEBUG ) {
+                System.err.println("NewtCanvasAWT."+dbgTag+".awtWait.0 @ "+currentThreadName());
+            }
+            newtChild.runOnEDTIfAvail(false /* wait */, task0);
+            loop.enter(); // keeps AWT EDT responsive
+            if( DEBUG ) {
+                System.err.println("NewtCanvasAWT."+dbgTag+".awtWait.X @ "+currentThreadName());
+            }
+
+            final Throwable throwable = throwableRef.get();
+            if( null != throwable ) {
+                if( throwable instanceof RuntimeException ) {
+                    throw (RuntimeException) throwable;
+                }
+                throw new RuntimeException(throwable);
+            }
+            return;
+        }
+
+        // Default behavior: execute task on current thread.
+        // All NEWT calls used here are thread-safe and will marshal to NEWT's EDT internally if needed.
+        task.run();
+    }
+
     private final void attachNewtChild() {
       if( null == newtChild || null == jawtWindow || newtChildAttached ) {
           return; // nop
@@ -1048,32 +1127,41 @@ public class NewtCanvasAWT extends java.awt.Canvas implements NativeWindowHolder
                              ", cont "+AWTMisc.getContainer(this));
       }
 
-      newtChildAttached = true;
-      newtChild.setFocusAction(null); // no AWT focus traversal ..
-      if(DEBUG) {
-        System.err.println("NewtCanvasAWT.attachNewtChild.1: newtChild: "+newtChild);
-      }
-      final int w = getWidth();
-      final int h = getHeight();
-      if(DEBUG) {
-          System.err.println("NewtCanvasAWT.attachNewtChild.2: size "+w+"x"+h+", isNValid "+newtChild.isNativeValid());
-      }
-      newtChild.setVisible(false);
-      newtChild.setSize(w, h);
-      updatePixelScale(getGraphicsConfiguration(), true /* force */); // AWT -> NEWT
-      newtChild.reparentWindow(jawtWindow, -1, -1, Window.REPARENT_HINT_BECOMES_VISIBLE);
-      newtChild.addSurfaceUpdatedListener(jawtWindow);
-      if( jawtWindow.isOffscreenLayerSurfaceEnabled() &&
-          0 != ( JAWTUtil.JAWT_OSX_CALAYER_QUIRK_POSITION & JAWTUtil.getOSXCALayerQuirks() ) ) {
-          AWTEDTExecutor.singleton.invoke(false, forceRelayout);
-      }
-      newtChild.setVisible(true);
-      configureNewtChild(true);
-      newtChild.sendWindowEvent(WindowEvent.EVENT_WINDOW_RESIZED); // trigger a resize/relayout to listener
+        newtChildAttached = true;
+        newtChild.setFocusAction(null); // no AWT focus traversal ..
+        if(DEBUG) {
+            System.err.println("NewtCanvasAWT.attachNewtChild.1: newtChild: "+newtChild);
+        }
+        final int w = getWidth();
+        final int h = getHeight();
+        if(DEBUG) {
+            System.err.println("NewtCanvasAWT.attachNewtChild.2: size "+w+"x"+h+", isNValid "+newtChild.isNativeValid());
+        }
+        updatePixelScale(getGraphicsConfiguration(), true /* force */); // AWT -> NEWT
 
-      if(DEBUG) {
-          System.err.println("NewtCanvasAWT.attachNewtChild.X: win "+newtWinHandleToHexString(newtChild)+", EDTUtil: cur "+newtChild.getScreen().getDisplay().getEDTUtil()+", comp "+this);
-      }
+        // Note: The NEWT reparent operation is synchronous by default and can deadlock on macOS 13+
+        // if performed on the AWT EDT. See runOnNewtEDTAndWaitOnAWTEDT(..) for details.
+        runOnNewtEDTAndWaitOnAWTEDT(new Runnable() {
+            @Override
+            public void run() {
+                newtChild.setVisible(false);
+                newtChild.setSize(w, h);
+                newtChild.reparentWindow(jawtWindow, -1, -1, Window.REPARENT_HINT_BECOMES_VISIBLE);
+                newtChild.addSurfaceUpdatedListener(jawtWindow);
+                newtChild.setVisible(true);
+                newtChild.sendWindowEvent(WindowEvent.EVENT_WINDOW_RESIZED); // trigger a resize/relayout to listener
+            }
+        }, "attachNewtChild");
+
+        if( jawtWindow.isOffscreenLayerSurfaceEnabled() &&
+                0 != ( JAWTUtil.JAWT_OSX_CALAYER_QUIRK_POSITION & JAWTUtil.getOSXCALayerQuirks() ) ) {
+            AWTEDTExecutor.singleton.invoke(false, forceRelayout);
+        }
+        configureNewtChild(true);
+
+        if(DEBUG) {
+            System.err.println("NewtCanvasAWT.attachNewtChild.X: win "+newtWinHandleToHexString(newtChild)+", EDTUtil: cur "+newtChild.getScreen().getDisplay().getEDTUtil()+", comp "+this);
+        }
     }
     private final Runnable forceRelayout = new Runnable() {
         @Override
@@ -1105,17 +1193,21 @@ public class NewtCanvasAWT extends java.awt.Canvas implements NativeWindowHolder
                              ", cont "+cont);
       }
 
-      newtChild.removeSurfaceUpdatedListener(jawtWindow);
-      newtChildAttached = false;
-      newtChild.setFocusAction(null); // no AWT focus traversal ..
-      configureNewtChild(false);
-      newtChild.setVisible(false);
+        newtChildAttached = false;
+        newtChild.setFocusAction(null); // no AWT focus traversal ..
+        configureNewtChild(false);
+        runOnNewtEDTAndWaitOnAWTEDT(new Runnable() {
+            @Override
+            public void run() {
+                newtChild.setVisible(false);
+                newtChild.removeSurfaceUpdatedListener(jawtWindow);
+                newtChild.reparentWindow(null, -1, -1, 0 /* hint */); // will destroy context (offscreen -> onscreen) and implicit detachSurfaceLayer
+            }
+        }, "detachNewtChild");
 
-      newtChild.reparentWindow(null, -1, -1, 0 /* hint */); // will destroy context (offscreen -> onscreen) and implicit detachSurfaceLayer
-
-      if(DEBUG) {
-          System.err.println("NewtCanvasAWT.detachNewtChild.X: win "+newtWinHandleToHexString(newtChild)+", EDTUtil: cur "+newtChild.getScreen().getDisplay().getEDTUtil()+", comp "+this);
-      }
+        if(DEBUG) {
+            System.err.println("NewtCanvasAWT.detachNewtChild.X: win "+newtWinHandleToHexString(newtChild)+", EDTUtil: cur "+newtChild.getScreen().getDisplay().getEDTUtil()+", comp "+this);
+        }
     }
 
   protected static String currentThreadName() { return "["+Thread.currentThread().getName()+", isAWT-EDT "+EventQueue.isDispatchThread()+"]"; }

--- a/src/test/com/jogamp/opengl/test/junit/jogl/awt/TestBug1478Deadlock01AWT.java
+++ b/src/test/com/jogamp/opengl/test/junit/jogl/awt/TestBug1478Deadlock01AWT.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2024 JogAmp Community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of JogAmp Community.
+ */
+
+package com.jogamp.opengl.test.junit.jogl.awt;
+
+import com.jogamp.common.os.Platform;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLCapabilities;
+import com.jogamp.opengl.GLEventListener;
+import com.jogamp.opengl.GLProfile;
+import com.jogamp.opengl.awt.GLCanvas;
+
+import com.jogamp.opengl.test.junit.util.AWTRobotUtil;
+import com.jogamp.opengl.test.junit.util.UITestCase;
+
+import java.awt.BorderLayout;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.junit.Assume;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestBug1478Deadlock01AWT extends UITestCase {
+    @Test(timeout = 10000)
+    public void test01SetVisiblePlainThenGLCanvas() throws InterruptedException, InvocationTargetException {
+        Assume.assumeTrue(Platform.getOSType() == Platform.OSType.MACOS);
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+        Assume.assumeTrue("GL2 not available", GLProfile.isAvailable(GLProfile.GL2));
+
+        final JFrame frame = new JFrame();
+        final PhotoFrame photoFrame = new PhotoFrame();
+        boolean shown = false;
+
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    frame.setSize(200, 150);
+                    frame.validate();
+                    frame.setVisible(true);
+
+                    photoFrame.setSize(320, 240);
+                    photoFrame.validate();
+                    photoFrame.setVisible(true);
+                }
+            });
+            shown = true;
+
+            final GLCanvas canvas = photoFrame.getCanvas();
+            Assume.assumeNotNull(canvas);
+
+            Assume.assumeTrue("GLCanvas didn't become visible", AWTRobotUtil.waitForVisible(canvas, true, null));
+            Assume.assumeTrue("GLCanvas didn't become realized", AWTRobotUtil.waitForRealized(canvas, true, null));
+        } catch (final Throwable t) {
+            t.printStackTrace();
+            Assume.assumeNoException(t);
+        } finally {
+            if( shown && !Thread.currentThread().isInterrupted() ) {
+                try {
+                    SwingUtilities.invokeAndWait(new Runnable() {
+                        @Override
+                        public void run() {
+                            photoFrame.setVisible(false);
+                            photoFrame.dispose();
+                            frame.setVisible(false);
+                            frame.dispose();
+                        }
+                    });
+                } catch (final Throwable t) {
+                    t.printStackTrace();
+                    Assume.assumeNoException(t);
+                }
+            }
+        }
+    }
+
+    private static class PhotoFrame extends JFrame {
+        private final PhotoPanel photoPanel;
+
+        PhotoFrame() {
+            photoPanel = new PhotoPanel();
+            setContentPane(photoPanel);
+        }
+
+        GLCanvas getCanvas() { return photoPanel.getCanvas(); }
+    }
+
+    private static class PhotoPanel extends JPanel implements GLEventListener {
+        private GLCanvas canvas;
+
+        PhotoPanel() {
+            setLayout(new BorderLayout());
+            initGLCanvas();
+        }
+
+        private void initGLCanvas() {
+            try {
+                final GLProfile glp = GLProfile.get(GLProfile.GL2);
+                final GLCapabilities caps = new GLCapabilities(glp);
+                canvas = new GLCanvas(caps);
+                canvas.addGLEventListener(this);
+                add(canvas, BorderLayout.CENTER);
+            } catch (final Throwable t) {
+                add(new JLabel("Unable to load 3d Libraries: " + t.getMessage()));
+            }
+        }
+
+        GLCanvas getCanvas() { return canvas; }
+
+        @Override
+        public void paintImmediately(final Rectangle r) { }
+
+        @Override
+        public void paintImmediately(final int x, final int y, final int w, final int h) { }
+
+        @Override
+        public void display(final GLAutoDrawable drawable) { }
+
+        @Override
+        public void init(final GLAutoDrawable drawable) { }
+
+        @Override
+        public void dispose(final GLAutoDrawable drawable) { }
+
+        @Override
+        public void reshape(final GLAutoDrawable drawable, final int i, final int i1, final int i2, final int i3) { }
+    }
+
+    public static void main(final String[] args) {
+        org.junit.runner.JUnitCore.main(TestBug1478Deadlock01AWT.class.getName());
+    }
+}
+


### PR DESCRIPTION
This PR fixes [BugZilla bug 1478](https://jogamp.org/bugzilla/show_bug.cgi?id=1478), where JOGL could deadlock on macOS 13/14 during AWT/Swing window realization and NEWT/AWT parenting (CALayer/JAWT path).

### What Was Deadlocking

- On macOS, JOGL sometimes needs to execute Cocoa/AppKit operations on the AppKit “main thread” (e.g., creating the dummy NSWindow/NSView used by the CALayer/JAWT offscreen-layer path).
- In the original freeze stack, the AWT Event Dispatch Thread (EDT) enters `OSXUtil.RunOnMainThread(.. waitUntilDone=true ..)` and blocks in `Object.wait()` while waiting for the AppKit-main-thread runnable to complete.
- On macOS 13/14, that AppKit-side work can (directly or indirectly) require the AWT EDT to keep pumping events during peer/window realization. If the EDT is fully blocked, the AppKit work never completes → deadlock.

**Newly-identified related deadlock (NEWT/AWT parenting):**

- `NewtCanvasAWT` attaches/detaches the NEWT child by calling `newtChild.reparentWindow(...)`, which is synchronous and (internally) waits for NEWT’s EDT.
- When `NewtCanvasAWT.attachNewtChild()` / `detachNewtChild()` run on the AWT EDT (e.g., during `validate()/layout/reshape`), the AWT EDT can end up waiting for the NEWT EDT while still needing to process AWT events for AppKit/CALayer/JAWT operations.
- This creates a cross-toolkit lock/wait cycle (AWT EDT ↔ NEWT EDT ↔ AppKit main thread), often surfacing as hangs/timeouts around `JAWTWindow.lockSurface()` / CALayer window creation.

### What I Changed

1) Keep the AWT EDT pumping while waiting for AppKit

- In `jogl/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java`:
  - Special-case: if `waitUntilDone==true` and the caller is the AWT EDT, do not use the old `sync.wait()` path.
  - Instead, create an AWT `SecondaryLoop` and enter it so the EDT continues dispatching events while we synchronously wait for the AppKit runnable to finish.
  - The AppKit-side runnable calls `SecondaryLoop.exit()` in a `finally` block to guarantee exit even on failure, and exceptions are captured + rethrown on the original caller.
  - Same pattern is applied to the synchronous variants (`RunOnMainThreadLong`, `RunOnMainThread(Function<...>)`).
  - To keep NativeWindow usable without AWT, `SecondaryLoop` is accessed via reflection in `AWTEDTUtil`, gated by `NativeWindowFactory.isAWTAvailable()`.

2) Prevent AWT↔NEWT parenting deadlocks by moving reparent to the NEWT EDT (while AWT stays responsive)

- In `jogl/src/newt/classes/com/jogamp/newt/awt/NewtCanvasAWT.java`:
  - Added `runOnNewtEDTAndWaitOnAWTEDT(..)`: if we’re on macOS and currently on the AWT EDT, we:
    - schedule the reparent/visibility/size sequence onto NEWT’s EDT via `newtChild.runOnEDTIfAvail(false, ...)`
    - enter an AWT `SecondaryLoop` on the AWT EDT until the NEWT task completes (and calls `exit()`).
  - `attachNewtChild()` and `detachNewtChild()` now use this wrapper around the synchronous `reparentWindow(...)` sequence, preventing the AWT EDT from hard-blocking while NEWT/AppKit needs it to pump events.

3) Reduce lock inversion during dummy NSWindow creation (CALayer/JAWT path)

- In `jogl/src/nativewindow/classes/jogamp/nativewindow/jawt/macosx/MacOSXJAWTWindow.java`:
  - For the offscreen-layer “dummy NSWindow/NSView” creation, temporarily drop the `JAWTWindow` surface lock and device lock around `OSXUtil.CreateNSWindow2(..)` and reacquire afterward, avoiding re-entrant deadlocks when multiple threads race to initialize the dummy window.

### Why This Fix Helps

- The core failure mode was “synchronous waiting while completely blocking the AWT EDT”.
- Using `SecondaryLoop` preserves synchronous semantics (call returns only after the target work completes) but keeps the AWT EDT responsive so any required AWT/AppKit event processing can proceed.
- Moving `reparentWindow(...)` execution onto NEWT’s EDT avoids a particularly problematic AWT-EDT→NEWT-EDT synchronous wait during sensitive realization/reparent phases on macOS.

### Regression Test

- Added `jogl/src/test/com/jogamp/opengl/test/junit/jogl/awt/TestBug1478Deadlock01AWT.java`, which reproduces the order-dependent scenario (plain `JFrame` shown first, then `JFrame` containing `GLCanvas`) and uses a JUnit timeout to catch deadlock regressions.

### Other testing

Ran all JOGL unit tests (`ant junit.run`), no issues found. Note that the freeze behavior from issue 1478 occurred on multiple unit tests, not only the SSCCE from issue 1478.