### PR TITLE
Fix DestroyNSWindow thread dispatch bug

### DIFF
--- a/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
+++ b/src/nativewindow/classes/jogamp/nativewindow/macosx/OSXUtil.java
@@ -182,7 +182,9 @@ public class OSXUtil implements ToolkitProperties {
     }
 
     public static void DestroyNSWindow(final long nsWindow) {
-      DestroyNSWindow0(nsWindow);
+      RunOnMainThread(true, false /* kickNSApp */, () -> {
+          DestroyNSWindow0(nsWindow);
+      });
     }
     public static long GetNSView(final long nsWindow, final boolean onMainThread) {
       if( onMainThread ) {


### PR DESCRIPTION
DestroyNSWindow is called from the SharedResourceRunner thread during OpenGL capability detection cleanup. MacOS requires NSWindow operations on the main thread, causing a crash:

"Must only be used from the main thread"

Fix OSXUtil.DestroyNSWindow to dispatch via RunOnMainThread when called from a background thread, matching how CreateNSWindow is already handled.

Related bug: https://jogamp.org/bugzilla/show_bug.cgi?id=1370